### PR TITLE
Misc: Remove broken finalizers

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/UIImage.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIImage.kt
@@ -101,15 +101,6 @@ open class UIImage @JvmOverloads constructor(
         super.draw(matrixStack)
     }
 
-    @Throws(Throwable::class)
-    protected fun finalize() {
-        if (!destroy) return
-        val glTextureId = texture?.glTextureId
-        if (glTextureId != null && glTextureId != 0 && glTextureId != -1) {
-            UGraphics.deleteTexture(glTextureId)
-        }
-    }
-
     override fun supply(image: CacheableImage) {
         if (texture != null) {
             image.applyTexture(texture)

--- a/src/main/kotlin/gg/essential/elementa/components/image/BlurHashImage.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/image/BlurHashImage.kt
@@ -63,14 +63,6 @@ open class BlurHashImage(private val hash: String) : UIComponent(), ImageProvide
         super.draw(matrixStack)
     }
 
-    @Throws(Throwable::class)
-    protected fun finalize() {
-        val glTextureId = texture.glTextureId
-        if (glTextureId != 0 && glTextureId != -1) {
-            UGraphics.deleteTexture(glTextureId)
-        }
-    }
-
     companion object {
         const val BASE_WIDTH = 50.0
         const val BASE_HEIGHT = 50.0

--- a/src/main/kotlin/gg/essential/elementa/components/image/MSDFComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/image/MSDFComponent.kt
@@ -127,16 +127,6 @@ open class MSDFComponent constructor(
 
     }
 
-    @Throws(Throwable::class)
-    protected fun finalize() {
-        if (!destroy) return
-        val glTextureId = texture?.glTextureId
-        if (glTextureId != null && glTextureId != 0 && glTextureId != -1) {
-            UGraphics.deleteTexture(glTextureId)
-        }
-    }
-
-
     override fun supply(image: CacheableImage) {
         if (texture != null) {
             image.applyTexture(texture)


### PR DESCRIPTION
These don't actually do anything useful because ReleasedDynamicTexture already
takes care of cleaning up after itself.
Quite the opposite actually, they double-free and they call OpenGL methods from
an arbitrary thread (which most likely won't have the appropriate GL context
bound) crashing the JVM in the worst case.