### PR TITLE
Build: Keep our internal dependencies entirely internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,6 @@ shadowJar {
     relocate("gg.essential.elementa", "your.package.elementa")
     // elementa dependencies
     relocate("gg.essential.universalcraft", "your.package.universalcraft")
-    relocate("org.dom4j", "your.package.dom4j")
-    relocate("org.commonmark", "your.package.commonmark")
 }
 tasks.named("reobfJar").configure { dependsOn(tasks.named("shadowJar")) }
 ```
@@ -180,8 +178,6 @@ tasks.shadowJar {
     relocate("gg.essential.elementa", "your.package.elementa")
     // elementa dependencies
     relocate("gg.essential.universalcraft", "your.package.universalcraft")
-    relocate("org.dom4j", "your.package.dom4j")
-    relocate("org.commonmark", "your.package.commonmark")
 }
 tasks.reobfJar { dependsOn(tasks.shadowJar) }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,12 @@ java.withSourcesJar()
 tasks.compileKotlin.setJvmDefault(if (platform.mcVersion >= 11400) "all" else "all-compatibility")
 loom.noServerRunConfigs()
 
+val internal = makeConfigurationForInternalDependencies {
+    relocate("org.dom4j", "gg.essential.elementa.impl.dom4j")
+    relocate("org.commonmark", "gg.essential.elementa.impl.commonmark")
+    remapStringsIn("org.dom4j.DocumentFactory")
+}
+
 dependencies {
     api("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
     api("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
@@ -24,10 +30,10 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin")
     }
 
-    implementation("org.commonmark:commonmark:0.17.1")
-    implementation("org.commonmark:commonmark-ext-gfm-strikethrough:0.17.1")
-    implementation("org.commonmark:commonmark-ext-ins:0.17.1")
-    implementation("org.dom4j:dom4j:2.1.1")
+    internal("org.commonmark:commonmark:0.17.1")
+    internal("org.commonmark:commonmark-ext-gfm-strikethrough:0.17.1")
+    internal("org.commonmark:commonmark-ext-ins:0.17.1")
+    internal("org.dom4j:dom4j:2.1.1")
 
     if (platform.isFabric) {
         val fabricApiVersion = when(platform.mcVersion) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
         maven("https://repo.essential.gg/repository/maven-public")
     }
     plugins {
-        val egtVersion = "0.1.1"
+        val egtVersion = "0.1.3"
         id("gg.essential.multi-version.root") version egtVersion
         id("gg.essential.multi-version.api-validation") version egtVersion
     }

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownRenderer.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownRenderer.kt
@@ -1,12 +1,12 @@
 package gg.essential.elementa.markdown
 
+import gg.essential.elementa.impl.commonmark.ext.gfm.strikethrough.Strikethrough
+import gg.essential.elementa.impl.commonmark.ext.gfm.strikethrough.StrikethroughExtension
+import gg.essential.elementa.impl.commonmark.ext.ins.Ins
+import gg.essential.elementa.impl.commonmark.ext.ins.InsExtension
+import gg.essential.elementa.impl.commonmark.node.*
+import gg.essential.elementa.impl.commonmark.parser.Parser
 import gg.essential.elementa.markdown.drawables.*
-import org.commonmark.ext.gfm.strikethrough.Strikethrough
-import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
-import org.commonmark.ext.ins.Ins
-import org.commonmark.ext.ins.InsExtension
-import org.commonmark.node.*
-import org.commonmark.parser.Parser
 import java.net.URL
 
 class MarkdownRenderer @JvmOverloads constructor(

--- a/src/main/kotlin/gg/essential/elementa/svg/SVGParser.kt
+++ b/src/main/kotlin/gg/essential/elementa/svg/SVGParser.kt
@@ -1,9 +1,9 @@
 package gg.essential.elementa.svg
 
+import gg.essential.elementa.impl.dom4j.Document
+import gg.essential.elementa.impl.dom4j.Element
+import gg.essential.elementa.impl.dom4j.io.SAXReader
 import gg.essential.elementa.svg.data.*
-import org.dom4j.Document
-import org.dom4j.Element
-import org.dom4j.io.SAXReader
 import java.lang.UnsupportedOperationException
 
 object SVGParser {

--- a/src/main/kotlin/gg/essential/elementa/svg/data/SVGCircle.kt
+++ b/src/main/kotlin/gg/essential/elementa/svg/data/SVGCircle.kt
@@ -1,6 +1,6 @@
 package gg.essential.elementa.svg.data
 
-import org.dom4j.Element
+import gg.essential.elementa.impl.dom4j.Element
 import org.lwjgl.opengl.GL11
 import java.nio.FloatBuffer
 import kotlin.math.PI

--- a/src/main/kotlin/gg/essential/elementa/svg/data/SVGLine.kt
+++ b/src/main/kotlin/gg/essential/elementa/svg/data/SVGLine.kt
@@ -1,6 +1,6 @@
 package gg.essential.elementa.svg.data
 
-import org.dom4j.Element
+import gg.essential.elementa.impl.dom4j.Element
 import org.lwjgl.opengl.GL11
 import java.nio.FloatBuffer
 

--- a/src/main/kotlin/gg/essential/elementa/svg/data/SVGPolyline.kt
+++ b/src/main/kotlin/gg/essential/elementa/svg/data/SVGPolyline.kt
@@ -1,6 +1,6 @@
 package gg.essential.elementa.svg.data
 
-import org.dom4j.Element
+import gg.essential.elementa.impl.dom4j.Element
 import org.lwjgl.opengl.GL11
 import java.nio.FloatBuffer
 

--- a/src/main/kotlin/gg/essential/elementa/svg/data/SVGRect.kt
+++ b/src/main/kotlin/gg/essential/elementa/svg/data/SVGRect.kt
@@ -1,6 +1,6 @@
 package gg.essential.elementa.svg.data
 
-import org.dom4j.Element
+import gg.essential.elementa.impl.dom4j.Element
 import org.lwjgl.opengl.GL11
 import java.nio.FloatBuffer
 


### PR DESCRIPTION
By relocating and bundling them ourselves. This way no consumer has to care
about our internal dependencies (and can't accidentally forget about them) and
Fabric users do not need to JiJ additional non-mod libraries to use
Elementa (only Elementa and UniversalCraft).