### PR TITLE
Build: Fix Html5Entities throwing due to relocation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ val internal = makeConfigurationForInternalDependencies {
     relocate("org.dom4j", "gg.essential.elementa.impl.dom4j")
     relocate("org.commonmark", "gg.essential.elementa.impl.commonmark")
     remapStringsIn("org.dom4j.DocumentFactory")
+    remapStringsIn("org.commonmark.internal.util.Html5Entities")
 }
 
 dependencies {


### PR DESCRIPTION
(requires essential-gradle-toolkit 0.1.5 to actually fix the issue; merge #58 first)

Because it tries to read a file from the same package but the string containing
that path did not get remapped.
Bumps essential-gradle-toolkit because previous versions did not remap
directory-like strings (those with an initial `/`).