### PR TITLE
Feature/cache component windows

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -4350,6 +4350,8 @@ public final class gg/essential/elementa/utils/ObservableAddEvent : gg/essential
 
 public final class gg/essential/elementa/utils/ObservableClearEvent : gg/essential/elementa/utils/ObservableListEvent {
 	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public final fun getOldChildren ()Ljava/util/List;
 }
 
 public final class gg/essential/elementa/utils/ObservableList : java/util/Observable, java/util/List, kotlin/jvm/internal/markers/KMutableList {

--- a/src/main/kotlin/gg/essential/elementa/components/Window.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/Window.kt
@@ -357,13 +357,14 @@ class Window @JvmOverloads constructor(
             )
         }
 
-        fun ofOrNull(component: UIComponent): Window? {
+        fun ofOrNull(component: UIComponent): Window? = component.cachedWindow ?: run {
             var current = component
 
-            while (current !is Window && current.hasParent && current.parent != current)
+            while (current !is Window && current.hasParent && current.parent != current) {
                 current = current.parent
+            }
 
-            return current as? Window
+            current as? Window
         }
     }
 }

--- a/src/main/kotlin/gg/essential/elementa/utils/ObservableList.kt
+++ b/src/main/kotlin/gg/essential/elementa/utils/ObservableList.kt
@@ -73,8 +73,9 @@ class ObservableList<T>(private val wrapped: MutableList<T>) : MutableList<T> by
     }
 
     override fun clear() {
+        val oldChildren = wrapped.toList()
         wrapped.clear()
-        update(ObservableClearEvent())
+        update(ObservableClearEvent(oldChildren))
     }
 
     override operator fun set(index: Int, element: T): T {
@@ -97,7 +98,9 @@ class ObservableAddEvent<T>(val element: IndexedValue<T>) : ObservableListEvent<
 
 class ObservableRemoveEvent<T>(val element: IndexedValue<T>) : ObservableListEvent<T>()
 
-class ObservableClearEvent<T> : ObservableListEvent<T>()
+class ObservableClearEvent<T>(val oldChildren: List<T>) : ObservableListEvent<T>() {
+    constructor() : this(listOf())
+}
 
 infix fun <T> T.withIndex(index: Int) = IndexedValue(index, this)
 


### PR DESCRIPTION
Don't have time to test particularly thoroughly at the moment, but it passed all my basic checks and doesn't *appear* to break anything in Essential.
A very basic test seems to say that after a few minutes playing around with Essential's GUIs, we get 2,906,250 total cache hits to only 4233 misses. (i.e., there's quite a lot of calls to that method, and 99.85% of them are now fulfilled by the cache).