### PR TITLE
Improve mouse input

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -46,7 +46,7 @@ public abstract class gg/essential/elementa/UIComponent : java/util/Observable {
 	public fun clearChildren ()Lgg/essential/elementa/UIComponent;
 	public final fun delay (JLkotlin/jvm/functions/Function0;)Lkotlin/jvm/functions/Function0;
 	public final fun depth ()I
-	public fun dragMouse (DDI)V
+	public fun dragMouse (FFI)V
 	public fun dragMouse (III)V
 	public fun draw ()V
 	public fun draw (Lgg/essential/universal/UMatrixStack;)V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -719,7 +719,6 @@ public final class gg/essential/elementa/components/Window : gg/essential/elemen
 	public fun getLeft ()F
 	public fun getRight ()F
 	public fun getTop ()F
-	public final fun getVersion ()Lgg/essential/elementa/ElementaVersion;
 	public fun getWidth ()F
 	public final fun isAreaVisible (DDDD)Z
 	public fun keyType (CI)V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -2,6 +2,7 @@ public final class gg/essential/elementa/ElementaVersion : java/lang/Enum {
 	public static final field Companion Lgg/essential/elementa/ElementaVersion$Companion;
 	public static final field V0 Lgg/essential/elementa/ElementaVersion;
 	public static final field V1 Lgg/essential/elementa/ElementaVersion;
+	public static final field V2 Lgg/essential/elementa/ElementaVersion;
 	public final fun enableFor (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static fun valueOf (Ljava/lang/String;)Lgg/essential/elementa/ElementaVersion;
 	public static fun values ()[Lgg/essential/elementa/ElementaVersion;
@@ -718,6 +719,7 @@ public final class gg/essential/elementa/components/Window : gg/essential/elemen
 	public fun getLeft ()F
 	public fun getRight ()F
 	public fun getTop ()F
+	public final fun getVersion ()Lgg/essential/elementa/ElementaVersion;
 	public fun getWidth ()F
 	public final fun isAreaVisible (DDDD)Z
 	public fun keyType (CI)V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -46,6 +46,7 @@ public abstract class gg/essential/elementa/UIComponent : java/util/Observable {
 	public fun clearChildren ()Lgg/essential/elementa/UIComponent;
 	public final fun delay (JLkotlin/jvm/functions/Function0;)Lkotlin/jvm/functions/Function0;
 	public final fun depth ()I
+	public fun dragMouse (DDI)V
 	public fun dragMouse (III)V
 	public fun draw ()V
 	public fun draw (Lgg/essential/universal/UMatrixStack;)V

--- a/src/main/java/com/example/examplemod/ComponentsGui.kt
+++ b/src/main/java/com/example/examplemod/ComponentsGui.kt
@@ -14,7 +14,7 @@ import gg.essential.elementa.markdown.MarkdownComponent
 import java.awt.Color
 import java.net.URL
 
-class ComponentsGui : WindowScreen(ElementaVersion.V1) {
+class ComponentsGui : WindowScreen(ElementaVersion.V2) {
     init {
         ComponentType("UIContainer") {
             val bar = UIBlock().constrain {

--- a/src/main/java/com/example/examplemod/ExampleGui.kt
+++ b/src/main/java/com/example/examplemod/ExampleGui.kt
@@ -18,7 +18,7 @@ import java.awt.Color
  * The example won't look particularly pretty, but that is up to the programmer
  * to design their GUIs how they wish.
  */
-class ExampleGui : WindowScreen(ElementaVersion.V1) {
+class ExampleGui : WindowScreen(ElementaVersion.V2) {
     // Our ExampleGui class will extend from WindowScreen
     // which is a subclass of GuiScreen that will call all mouse/keyboard
     // events for us.

--- a/src/main/java/com/example/examplemod/ExampleServerList.kt
+++ b/src/main/java/com/example/examplemod/ExampleServerList.kt
@@ -13,7 +13,7 @@ import gg.essential.universal.UScreen
 import java.awt.Color
 import java.net.URL
 
-class ExampleServerList : WindowScreen(ElementaVersion.V1) {
+class ExampleServerList : WindowScreen(ElementaVersion.V2) {
 //    val serverList = (ScrollComponent().constrain {
 //        y = 30.pixels()
 //        width = RelativeConstraint()

--- a/src/main/java/com/example/examplemod/ExamplesGui.kt
+++ b/src/main/java/com/example/examplemod/ExamplesGui.kt
@@ -13,7 +13,7 @@ import java.awt.Color
  * List of buttons to open a specific example gui.
  * See ExampleGui (singular) for a well-commented example gui.
  */
-class ExamplesGui : WindowScreen(ElementaVersion.V1) {
+class ExamplesGui : WindowScreen(ElementaVersion.V2) {
     private val container by ScrollComponent().constrain {
         y = 3.pixels()
         width = 100.percent()

--- a/src/main/java/com/example/examplemod/JavaTestGui.java
+++ b/src/main/java/com/example/examplemod/JavaTestGui.java
@@ -21,7 +21,7 @@ public class JavaTestGui extends WindowScreen {
         .enableEffect(new ScissorEffect());
 
     public JavaTestGui() {
-        super(ElementaVersion.V1);
+        super(ElementaVersion.V2);
         box.onMouseEnterRunnable(() -> {
             // Animate, set color, etc.
             AnimatingConstraints anim = box.makeAnimation();

--- a/src/main/java/com/example/examplemod/KtTestGui.kt
+++ b/src/main/java/com/example/examplemod/KtTestGui.kt
@@ -16,7 +16,7 @@ import gg.essential.elementa.utils.withAlpha
 import net.minecraft.util.text.TextFormatting
 import java.awt.Color
 
-class KtTestGui : WindowScreen(ElementaVersion.V1) {
+class KtTestGui : WindowScreen(ElementaVersion.V2) {
     private val myTextBox = UIBlock(Color(0, 0, 0, 255))
 
     init {

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -28,6 +28,21 @@ enum class ElementaVersion {
      */
     V1,
 
+    /**
+     * This Elementa version improves the behavior of mouse input in two ways
+     *
+     * 1. In Minecraft versions <=1.12.2, the game calculates the position of the mouse input in an integer context
+     * relative to scaled pixels. However, Elementa uses real pixels to determine the position of components leading
+     * to situations where certain components or parts of components are not clickable due the game truncating the decimal.
+     * This Elementa version improves this behavior by restoring the decimal component of mouse clicks to the mouse positions
+     * on affected versions.
+     *
+     * 2. Minecraft mouse click input is positioned in the top left corner of a pixel. As a result, the left and top pixel of
+     * a component do not register clicks and components with a width or height of 1 are also not clickable. This Elementa version
+     * improves this behavior by moving the click to the center of the pixel.
+     */
+    V2,
+
     ;
 
     /**
@@ -62,6 +77,9 @@ Be sure to read through all the changes between your current version and your ne
         internal val v0 = V0
         @Suppress("DEPRECATION")
         internal val v1 = V1
+        @Suppress("DEPRECATION")
+        internal val v2 = V2
+
 
         @PublishedApi
         internal var active: ElementaVersion = v0

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -26,6 +26,7 @@ enum class ElementaVersion {
      * Additionally they will always reset the depth test state to disabled and the depth test function to LEQUAL before
      * returning (this matches the default state during GUI rendering but may be important in some special use cases).
      */
+    @Deprecated(DEPRECATION_MESSAGE)
     V1,
 
     /**

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -29,7 +29,7 @@ enum class ElementaVersion {
     V1,
 
     /**
-     * This Elementa version improves the behavior of mouse input in two ways
+     * This Elementa version improves the behavior of mouse input in three ways
      *
      * 1. In Minecraft versions <=1.12.2, the game calculates the position of the mouse input in an integer context
      * relative to scaled pixels. However, Elementa uses real pixels to determine the position of components leading
@@ -49,6 +49,12 @@ enum class ElementaVersion {
      * [gg.essential.elementa.utils.guiHint].
      * E.g. if the user clicks on the MC pixel at 3/4 with their GUI scale set to 2, the click used to be processed at
      * 3.0/4.0, but with this change it will appear at 3.25/4.25 (because 0.25 is half a real pixel at scale 2).
+     *
+     * 3. [gg.essential.elementa.components.Window] will now call the new [gg.essential.elementa.UIComponent.dragMouse]
+     * override (the one using Double) instead of the old one (using Int). This allows the drag listeners to receive
+     * high quality mouse coordinates (including the two changes above) but it may be breaking if you rely on an
+     * override of that method. If you do, then you should switch to using the new override at the same time as you
+     * upgrade to the new version (or override both if you need to maintain support for old versions).
      */
     V2,
 

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -33,13 +33,22 @@ enum class ElementaVersion {
      *
      * 1. In Minecraft versions <=1.12.2, the game calculates the position of the mouse input in an integer context
      * relative to scaled pixels. However, Elementa uses real pixels to determine the position of components leading
-     * to situations where certain components or parts of components are not clickable due the game truncating the decimal.
-     * This Elementa version improves this behavior by restoring the decimal component of mouse clicks to the mouse positions
-     * on affected versions.
+     * to situations where certain components or parts of components are not clickable due the game truncating the fractional part.
+     * This Elementa version improves this behavior by restoring the fractional component of mouse clicks to the mouse positions
+     * in [gg.essential.elementa.WindowScreen.onMouseClicked] if it is not already present
      *
      * 2. Minecraft mouse click input is positioned in the top left corner of a pixel. As a result, the left and top pixel of
      * a component do not register clicks and components with a width or height of 1 are also not clickable. This Elementa version
-     * improves this behavior by moving the click to the center of the pixel.
+     * improves this behavior by offsetting mouse coordinates to the center of the real pixel.
+     * In particular, [gg.essential.elementa.components.Window.mouseClick] will add half a real pixel to the passed
+     * coordinates and [gg.essential.elementa.UIComponent.getMousePosition] will add half a real pixel to the returned
+     * coordinates.
+     * As a result, if you have previously relied on the exact distance between a click and a component, beware that
+     * this value will now be off by up to half a real pixel compared to what it used to be. If required, you can get
+     * back the original real-pixel-aligned value by rounding down to the nearest real pixel via
+     * [gg.essential.elementa.utils.guiHint].
+     * E.g. if the user clicks on the MC pixel at 3/4 with their GUI scale set to 2, the click used to be processed at
+     * 3.0/4.0, but with this change it will appear at 3.25/4.25 (because 0.25 is half a real pixel at scale 2).
      */
     V2,
 

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -51,7 +51,7 @@ enum class ElementaVersion {
      * 3.0/4.0, but with this change it will appear at 3.25/4.25 (because 0.25 is half a real pixel at scale 2).
      *
      * 3. [gg.essential.elementa.components.Window] will now call the new [gg.essential.elementa.UIComponent.dragMouse]
-     * override (the one using Double) instead of the old one (using Int). This allows the drag listeners to receive
+     * override (the one using Float) instead of the old one (using Int). This allows the drag listeners to receive
      * high quality mouse coordinates (including the two changes above) but it may be breaking if you rely on an
      * override of that method. If you do, then you should switch to using the new override at the same time as you
      * upgrade to the new version (or override both if you need to maintain support for old versions).

--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -643,12 +643,12 @@ abstract class UIComponent : Observable() {
     }
 
     @Deprecated(
-        "Replaced by override using Double for coordinates.",
-        ReplaceWith("dragMouse(mouseX.toDouble(), mouseY.toDouble(), button)")
+        "Replaced by override using Float for coordinates.",
+        ReplaceWith("dragMouse(mouseX.toFloat(), mouseY.toFloat(), button)")
     )
     @Suppress("DEPRECATION")
     open fun dragMouse(mouseX: Int, mouseY: Int, button: Int) {
-        doDragMouse(mouseX.toDouble(), mouseY.toDouble(), button) { dragMouse(mouseX, mouseY, button) }
+        doDragMouse(mouseX.toFloat(), mouseY.toFloat(), button) { dragMouse(mouseX, mouseY, button) }
     }
 
     /**
@@ -659,19 +659,19 @@ abstract class UIComponent : Observable() {
      * Note: This method is only called by [Window]s using an [ElementaVersion] of 2 or greater. Older versions will
      *       only call the deprecated integer overload.
      */
-    open fun dragMouse(mouseX: Double, mouseY: Double, button: Int) {
+    open fun dragMouse(mouseX: Float, mouseY: Float, button: Int) {
         doDragMouse(mouseX, mouseY, button) { dragMouse(mouseX, mouseY, button) }
     }
 
-    private inline fun doDragMouse(mouseX: Double, mouseY: Double, button: Int, superCall: UIComponent.() -> Unit) {
-        if (lastDraggedMouseX == mouseX && lastDraggedMouseY == mouseY)
+    private inline fun doDragMouse(mouseX: Float, mouseY: Float, button: Int, superCall: UIComponent.() -> Unit) {
+        if (lastDraggedMouseX == mouseX.toDouble() && lastDraggedMouseY == mouseY.toDouble())
             return
 
-        lastDraggedMouseX = mouseX
-        lastDraggedMouseY = mouseY
+        lastDraggedMouseX = mouseX.toDouble()
+        lastDraggedMouseY = mouseY.toDouble()
 
-        val relativeX = mouseX.toFloat() - getLeft()
-        val relativeY = mouseY.toFloat() - getTop()
+        val relativeX = mouseX - getLeft()
+        val relativeY = mouseY - getTop()
 
         for (listener in mouseDragListeners)
             this.listener(relativeX, relativeY, button)

--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -357,7 +357,7 @@ abstract class UIComponent : Observable() {
     internal fun pixelCoordinatesToPixelCenter(mouseX: Double, mouseY: Double): Pair<Double, Double> {
         // Move the position of a click to the center of a pixel. See [ElementaVersion.v2] for more info
         return if ((Window.ofOrNull(this)?.version ?: ElementaVersion.v0) >= ElementaVersion.v2) {
-            val halfPixel = 0.5 / UResolution.scaleFactor.toFloat()
+            val halfPixel = 0.5 / UResolution.scaleFactor
             mouseX + halfPixel to mouseY + halfPixel
         } else {
             mouseX to mouseY

--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -351,7 +351,15 @@ abstract class UIComponent : Observable() {
     }
 
     protected fun getMousePosition(): Pair<Float, Float> {
-        return UIComponent.getMouseX() to UIComponent.getMouseY()
+        return transformMouseLocation(getMouseX(), getMouseY())
+    }
+
+    internal fun transformMouseLocation(mouseX: Float, mouseY: Float): Pair<Float, Float> {
+        // Move the position of a click to the center of a pixel. See [ElementaVersion.v2] for more info
+        if ((cachedWindow?.version ?: ElementaVersion.v0) >= ElementaVersion.V2) {
+            return mouseX + 0.5f / UResolution.scaleFactor.toFloat() to mouseY + 0.5f / UResolution.scaleFactor.toFloat()
+        }
+        return mouseX to mouseY
     }
 
     open fun isPointInside(x: Float, y: Float): Boolean {

--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -351,15 +351,17 @@ abstract class UIComponent : Observable() {
     }
 
     protected fun getMousePosition(): Pair<Float, Float> {
-        return transformMouseLocation(getMouseX(), getMouseY())
+        return pixelCoordinatesToPixelCenter(UMouse.Scaled.x, UMouse.Scaled.y).let { (x, y) -> x.toFloat() to y.toFloat() }
     }
 
-    internal fun transformMouseLocation(mouseX: Float, mouseY: Float): Pair<Float, Float> {
+    internal fun pixelCoordinatesToPixelCenter(mouseX: Double, mouseY: Double): Pair<Double, Double> {
         // Move the position of a click to the center of a pixel. See [ElementaVersion.v2] for more info
-        if ((cachedWindow?.version ?: ElementaVersion.v0) >= ElementaVersion.V2) {
-            return mouseX + 0.5f / UResolution.scaleFactor.toFloat() to mouseY + 0.5f / UResolution.scaleFactor.toFloat()
+        return if ((Window.ofOrNull(this)?.version ?: ElementaVersion.v0) >= ElementaVersion.v2) {
+            val halfPixel = 0.5 / UResolution.scaleFactor.toFloat()
+            mouseX + halfPixel to mouseY + halfPixel
+        } else {
+            mouseX to mouseY
         }
-        return mouseX to mouseY
     }
 
     open fun isPointInside(x: Float, y: Float): Boolean {

--- a/src/main/kotlin/gg/essential/elementa/WindowScreen.kt
+++ b/src/main/kotlin/gg/essential/elementa/WindowScreen.kt
@@ -8,9 +8,11 @@ import gg.essential.elementa.components.Window
 import gg.essential.elementa.constraints.animation.*
 import gg.essential.universal.UKeyboard
 import gg.essential.universal.UMatrixStack
+import gg.essential.universal.UMouse
 import gg.essential.universal.UScreen
 
 import java.awt.Color
+import kotlin.math.floor
 import kotlin.reflect.KMutableProperty0
 
 /**
@@ -18,7 +20,7 @@ import kotlin.reflect.KMutableProperty0
  * functions for Elementa Gui programming.
  */
 abstract class WindowScreen @JvmOverloads constructor(
-    version: ElementaVersion,
+    private val version: ElementaVersion,
     private val enableRepeatKeys: Boolean = true,
     private val drawDefaultBackground: Boolean = true,
     restoreCurrentGuiOnClose: Boolean = false,
@@ -65,8 +67,22 @@ abstract class WindowScreen @JvmOverloads constructor(
     override fun onMouseClicked(mouseX: Double, mouseY: Double, mouseButton: Int) {
         super.onMouseClicked(mouseX, mouseY, mouseButton)
 
+        // Restore decimal value to mouse locations if not present.
+        // See [ElementaVersion.V2] for more info
+        val (adjustedMouseX, adjustedMouseY) = if (
+            version >= ElementaVersion.V2 &&
+            (mouseX == floor(mouseX) && mouseY == floor(mouseY))
+        ) {
+            val x = UMouse.Scaled.x
+            val y = UMouse.Scaled.y
+
+            mouseX + (x - floor(x)) to mouseY + (y - floor(y))
+        } else {
+            mouseX to mouseY
+        }
+
         // We also need to pass along clicks
-        window.mouseClick(mouseX, mouseY, mouseButton)
+        window.mouseClick(adjustedMouseX, adjustedMouseY, mouseButton)
     }
 
     override fun onMouseReleased(mouseX: Double, mouseY: Double, state: Int) {

--- a/src/main/kotlin/gg/essential/elementa/WindowScreen.kt
+++ b/src/main/kotlin/gg/essential/elementa/WindowScreen.kt
@@ -69,17 +69,15 @@ abstract class WindowScreen @JvmOverloads constructor(
 
         // Restore decimal value to mouse locations if not present.
         // See [ElementaVersion.V2] for more info
-        val (adjustedMouseX, adjustedMouseY) = if (
-            version >= ElementaVersion.V2 &&
-            (mouseX == floor(mouseX) && mouseY == floor(mouseY))
-        ) {
-            val x = UMouse.Scaled.x
-            val y = UMouse.Scaled.y
+        val (adjustedMouseX, adjustedMouseY) =
+            if (version >= ElementaVersion.v2 && (mouseX == floor(mouseX) && mouseY == floor(mouseY))) {
+                val x = UMouse.Scaled.x
+                val y = UMouse.Scaled.y
 
-            mouseX + (x - floor(x)) to mouseY + (y - floor(y))
-        } else {
-            mouseX to mouseY
-        }
+                mouseX + (x - floor(x)) to mouseY + (y - floor(y))
+            } else {
+                mouseX to mouseY
+            }
 
         // We also need to pass along clicks
         window.mouseClick(adjustedMouseX, adjustedMouseY, mouseButton)

--- a/src/main/kotlin/gg/essential/elementa/components/Window.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/Window.kt
@@ -238,7 +238,12 @@ class Window @JvmOverloads constructor(
     override fun animationFrame() {
         if (currentMouseButton != -1) {
             val (mouseX, mouseY) = getMousePosition()
-            dragMouse(mouseX.toInt(), mouseY.toInt(), currentMouseButton)
+            if (version >= ElementaVersion.v2) {
+                dragMouse(mouseX.toDouble(), mouseY.toDouble(), currentMouseButton)
+            } else {
+                @Suppress("DEPRECATION")
+                dragMouse(mouseX.toInt(), mouseY.toInt(), currentMouseButton)
+            }
         }
 
         if (componentRequestingFocus != null && componentRequestingFocus != focusedComponent) {

--- a/src/main/kotlin/gg/essential/elementa/components/Window.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/Window.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit
  * or animating.
  */
 class Window @JvmOverloads constructor(
-    private val version: ElementaVersion,
+    val version: ElementaVersion,
     val animationFPS: Int = 244
 ) : UIComponent() {
     private var systemTime = -1L
@@ -175,6 +175,11 @@ class Window @JvmOverloads constructor(
     override fun mouseClick(mouseX: Double, mouseY: Double, button: Int) {
         requireMainThread()
 
+        //  Override mouse positions to be in the center of the pixel on Elementa versions
+        //  2 and over. See [ElementaVersion.V2] for more info.
+        val (mouseX, mouseY) = super.transformMouseLocation(mouseX.toFloat(), mouseY.toFloat()).let { (x, y) ->
+            x.toDouble() to y.toDouble()
+        }
         currentMouseButton = button
 
         clickInterceptor?.let {

--- a/src/main/kotlin/gg/essential/elementa/components/Window.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/Window.kt
@@ -239,7 +239,7 @@ class Window @JvmOverloads constructor(
         if (currentMouseButton != -1) {
             val (mouseX, mouseY) = getMousePosition()
             if (version >= ElementaVersion.v2) {
-                dragMouse(mouseX.toDouble(), mouseY.toDouble(), currentMouseButton)
+                dragMouse(mouseX, mouseY, currentMouseButton)
             } else {
                 @Suppress("DEPRECATION")
                 dragMouse(mouseX.toInt(), mouseY.toInt(), currentMouseButton)

--- a/src/main/kotlin/gg/essential/elementa/components/Window.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/Window.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit
  * or animating.
  */
 class Window @JvmOverloads constructor(
-    val version: ElementaVersion,
+    internal val version: ElementaVersion,
     val animationFPS: Int = 244
 ) : UIComponent() {
     private var systemTime = -1L
@@ -177,9 +177,12 @@ class Window @JvmOverloads constructor(
 
         //  Override mouse positions to be in the center of the pixel on Elementa versions
         //  2 and over. See [ElementaVersion.V2] for more info.
-        val (mouseX, mouseY) = super.transformMouseLocation(mouseX.toFloat(), mouseY.toFloat()).let { (x, y) ->
-            x.toDouble() to y.toDouble()
-        }
+        val (adjustedX, adjustedY) = pixelCoordinatesToPixelCenter(mouseX, mouseY)
+
+        doMouseClick(adjustedX, adjustedY, button)
+    }
+
+    private fun doMouseClick(mouseX: Double, mouseY: Double, button: Int) {
         currentMouseButton = button
 
         clickInterceptor?.let {

--- a/src/main/kotlin/gg/essential/elementa/constraints/resolution/ConstraintResolutionGui.kt
+++ b/src/main/kotlin/gg/essential/elementa/constraints/resolution/ConstraintResolutionGui.kt
@@ -20,7 +20,7 @@ class ConstraintResolutionGui(
     private val guiName: String,
     private val gui: UIComponent,
     private val nodes: List<ResolverNode>?
-) : WindowScreen(ElementaVersion.V1) {
+) : WindowScreen(ElementaVersion.V2) {
 
     private val guiView by GuiView().constrain {
         width = 100.percent


### PR DESCRIPTION
This PR exists to improve Elementa mouse input by introducing Elementa Version v2.

1. In Minecraft versions <=1.12.2, the game calculates the position of the mouse input in an integer context
relative to scaled pixels. However, Elementa uses real pixels to determine the position of components leading
to situations where certain components or parts of components are not clickable due the game truncating the decimal.
This Elementa version improves this behavior by restoring the decimal component of mouse clicks to the mouse positions
on affected versions.

2. Minecraft mouse click input is positioned in the top left corner of a pixel. As a result, the left and top pixel of
a component do not register clicks and components with a width or height of 1 are also not clickable. This Elementa version
improves this behavior by moving the click to the center of the pixel.