### PR TITLE
UIComponent: Warn when beforeDraw wasn't called

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -613,6 +613,7 @@ public final class gg/essential/elementa/components/UIPoint : gg/essential/eleme
 	public fun <init> (Lgg/essential/elementa/constraints/PositionConstraint;Lgg/essential/elementa/constraints/PositionConstraint;)V
 	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;)V
 	public fun <init> (Lkotlin/Pair;)V
+	public fun draw (Lgg/essential/universal/UMatrixStack;)V
 	public final fun getAbsolutePoint ()Lkotlin/Pair;
 	public final fun getAbsoluteX ()F
 	public final fun getAbsoluteY ()F
@@ -1072,6 +1073,7 @@ public class gg/essential/elementa/components/input/UITextInput : gg/essential/e
 public final class gg/essential/elementa/components/inspector/ArrowComponent : gg/essential/elementa/components/TreeArrowComponent {
 	public fun <init> (Z)V
 	public fun close ()V
+	public fun draw (Lgg/essential/universal/UMatrixStack;)V
 	public fun open ()V
 }
 

--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -1,6 +1,7 @@
 package gg.essential.elementa
 
 import gg.essential.elementa.components.UIBlock
+import gg.essential.elementa.components.UIContainer
 import gg.essential.elementa.components.Window
 import gg.essential.elementa.constraints.*
 import gg.essential.elementa.constraints.animation.*
@@ -506,6 +507,15 @@ abstract class UIComponent : Observable() {
     }
 
     open fun beforeDraw(matrixStack: UMatrixStack) {
+        if (didCallBeforeDraw && !warnedAboutBeforeDraw) {
+            warnedAboutBeforeDraw = true
+            val advice = if (this is UIContainer) {
+                "It should not be extending UIContainer if it overrides `draw` and calls `beforeDraw` on its own."
+            } else {
+                "Make sure that none of its super classes already call `beforeDraw`."
+            }
+            handleInvalidUsage("${javaClass.name} called `beforeDraw` more than once without a call to `draw`. $advice")
+        }
         didCallBeforeDraw = true
 
         effects.forEach { it.beforeDraw(matrixStack) }

--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -95,6 +95,9 @@ abstract class UIComponent : Observable() {
     protected var isInitialized = false
     private var isFloating = false
 
+    private var didCallBeforeDraw = false
+    private var warnedAboutBeforeDraw = false
+
     internal var cachedWindow: Window? = null
 
     private fun setWindowCacheOnChangedChild(possibleEvent: Any) {
@@ -425,6 +428,14 @@ abstract class UIComponent : Observable() {
             afterInitialization()
         }
 
+        if (!didCallBeforeDraw && !warnedAboutBeforeDraw) {
+            warnedAboutBeforeDraw = true
+            handleInvalidUsage("${javaClass.name} failed to call `beforeDraw` at the start of its `draw` method. " +
+                "Consider extending UIContainer if you do not wish to override the draw method. " +
+                "If you do need to override it, then be sure to call `beforeDraw` from it before you do any drawing.")
+        }
+        didCallBeforeDraw = false
+
         // Draw colored outline around the components
         if (elementaDebug) {
             if (ScissorEffect.currentScissorState != null) {
@@ -495,6 +506,8 @@ abstract class UIComponent : Observable() {
     }
 
     open fun beforeDraw(matrixStack: UMatrixStack) {
+        didCallBeforeDraw = true
+
         effects.forEach { it.beforeDraw(matrixStack) }
     }
 

--- a/src/main/kotlin/gg/essential/elementa/components/UIPoint.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIPoint.kt
@@ -3,6 +3,7 @@ package gg.essential.elementa.components
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.constraints.PositionConstraint
 import gg.essential.elementa.dsl.pixels
+import gg.essential.universal.UMatrixStack
 
 /**
  * "Component" with no width/height and therefore no visible rendering.
@@ -47,4 +48,9 @@ class UIPoint(
     fun withY(y: PositionConstraint) = UIPoint(x, y)
 
     fun withY(y: Number) = UIPoint(x, y.pixels())
+
+    override fun draw(matrixStack: UMatrixStack) {
+        beforeDraw(matrixStack)
+        super.draw(matrixStack)
+    }
 }

--- a/src/main/kotlin/gg/essential/elementa/components/Window.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/Window.kt
@@ -96,6 +96,7 @@ class Window @JvmOverloads constructor(
             }
 
             mouseMove(this)
+            beforeDraw(matrixStack)
             super.draw(matrixStack)
         } catch (e: Throwable) {
             cancelDrawing = true

--- a/src/main/kotlin/gg/essential/elementa/components/inspector/ArrowComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/inspector/ArrowComponent.kt
@@ -5,6 +5,7 @@ import gg.essential.elementa.components.TreeArrowComponent
 import gg.essential.elementa.dsl.childOf
 import gg.essential.elementa.dsl.constrain
 import gg.essential.elementa.dsl.pixels
+import gg.essential.universal.UMatrixStack
 
 class ArrowComponent(private val empty: Boolean) : TreeArrowComponent() {
     private val closedIcon = SVGComponent.ofResource("/svg/square-plus.svg").constrain {
@@ -34,5 +35,10 @@ class ArrowComponent(private val empty: Boolean) : TreeArrowComponent() {
     override fun close() {
         if (!empty)
             replaceChild(closedIcon, openIcon)
+    }
+
+    override fun draw(matrixStack: UMatrixStack) {
+        beforeDraw(matrixStack)
+        super.draw(matrixStack)
     }
 }


### PR DESCRIPTION
Because it's easy to forget to call that, especially because no one really tells
you that you have to do it. That part is fixed now.