### PR TITLE
Fix State Usages

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -1854,6 +1854,7 @@ public final class gg/essential/elementa/constraints/RelativeConstraint : gg/ess
 	public fun <init> ()V
 	public fun <init> (F)V
 	public synthetic fun <init> (FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lgg/essential/elementa/state/State;)V
 	public final fun bindValue (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/RelativeConstraint;
 	public fun getCachedValue ()Ljava/lang/Float;
 	public synthetic fun getCachedValue ()Ljava/lang/Object;

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -1285,6 +1285,7 @@ public final class gg/essential/elementa/constraints/AdditiveConstraint : gg/ess
 
 public final class gg/essential/elementa/constraints/AlphaAspectColorConstraint : gg/essential/elementa/constraints/ColorConstraint {
 	public fun <init> ()V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
 	public fun <init> (Ljava/awt/Color;F)V
 	public synthetic fun <init> (Ljava/awt/Color;FILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun bindAlpha (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/AlphaAspectColorConstraint;
@@ -1478,6 +1479,7 @@ public final class gg/essential/elementa/constraints/ColorConstraint$DefaultImpl
 
 public final class gg/essential/elementa/constraints/ConstantColorConstraint : gg/essential/elementa/constraints/ColorConstraint {
 	public fun <init> ()V
+	public fun <init> (Lgg/essential/elementa/state/State;)V
 	public fun <init> (Ljava/awt/Color;)V
 	public synthetic fun <init> (Ljava/awt/Color;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun bindColor (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/ConstantColorConstraint;
@@ -1766,6 +1768,10 @@ public final class gg/essential/elementa/constraints/PixelConstraint : gg/essent
 	public fun <init> (FZ)V
 	public fun <init> (FZZ)V
 	public synthetic fun <init> (FZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lgg/essential/elementa/state/State;)V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
+	public synthetic fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun bindAlignOpposite (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/PixelConstraint;
 	public final fun bindAlignOutside (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/PixelConstraint;
 	public final fun bindValue (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/PixelConstraint;
@@ -1919,6 +1925,7 @@ public final class gg/essential/elementa/constraints/RoundingConstraint$Mode : j
 
 public final class gg/essential/elementa/constraints/ScaleConstraint : gg/essential/elementa/constraints/MasterConstraint {
 	public fun <init> (Lgg/essential/elementa/constraints/SuperConstraint;F)V
+	public fun <init> (Lgg/essential/elementa/constraints/SuperConstraint;Lgg/essential/elementa/state/State;)V
 	public fun animationFrame ()V
 	public final fun bindValue (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/ScaleConstraint;
 	public fun getCachedValue ()Ljava/lang/Float;
@@ -2586,14 +2593,8 @@ public final class gg/essential/elementa/effects/OutlineEffect$Side : java/lang/
 
 public final class gg/essential/elementa/effects/RecursiveFadeEffect : gg/essential/elementa/effects/Effect {
 	public fun <init> ()V
-	public fun <init> (F)V
-	public synthetic fun <init> (FILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lgg/essential/elementa/state/State;)V
 	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
 	public synthetic fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Z)V
-	public fun <init> (ZF)V
-	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun rebindIsOverridden (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/effects/RecursiveFadeEffect;
 	public final fun rebindOverriddenAlphaPercentage (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/effects/RecursiveFadeEffect;
 	public final fun remove ()V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -680,6 +680,8 @@ public class gg/essential/elementa/components/UIText : gg/essential/elementa/UIC
 
 public class gg/essential/elementa/components/UIWrappedText : gg/essential/elementa/UIComponent {
 	public fun <init> ()V
+	public fun <init> (Lgg/essential/elementa/state/State;)V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
 	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
 	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Z)V
 	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ZZ)V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -657,6 +657,7 @@ public class gg/essential/elementa/components/UIShape : gg/essential/elementa/UI
 public class gg/essential/elementa/components/UIText : gg/essential/elementa/UIComponent {
 	public fun <init> ()V
 	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
+	public synthetic fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Z)V
 	public fun <init> (Ljava/lang/String;ZLjava/awt/Color;)V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -2547,6 +2547,11 @@ public abstract class gg/essential/elementa/effects/Effect {
 }
 
 public final class gg/essential/elementa/effects/OutlineEffect : gg/essential/elementa/effects/Effect {
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Z)V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ZZ)V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ZZLjava/util/Set;)V
+	public synthetic fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ZZLjava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/awt/Color;F)V
 	public fun <init> (Ljava/awt/Color;FZ)V
 	public fun <init> (Ljava/awt/Color;FZZ)V
@@ -2581,8 +2586,14 @@ public final class gg/essential/elementa/effects/OutlineEffect$Side : java/lang/
 
 public final class gg/essential/elementa/effects/RecursiveFadeEffect : gg/essential/elementa/effects/Effect {
 	public fun <init> ()V
+	public fun <init> (F)V
+	public synthetic fun <init> (FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lgg/essential/elementa/state/State;)V
 	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
 	public synthetic fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Z)V
+	public fun <init> (ZF)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun rebindIsOverridden (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/effects/RecursiveFadeEffect;
 	public final fun rebindOverriddenAlphaPercentage (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/effects/RecursiveFadeEffect;
 	public final fun remove ()V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -264,6 +264,7 @@ public abstract class gg/essential/elementa/WindowScreen : gg/essential/universa
 public class gg/essential/elementa/components/GradientComponent : gg/essential/elementa/components/UIBlock {
 	public static final field Companion Lgg/essential/elementa/components/GradientComponent$Companion;
 	public fun <init> ()V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
 	public fun <init> (Ljava/awt/Color;)V
 	public fun <init> (Ljava/awt/Color;Ljava/awt/Color;)V
 	public fun <init> (Ljava/awt/Color;Ljava/awt/Color;Lgg/essential/elementa/components/GradientComponent$GradientDirection;)V
@@ -655,6 +656,7 @@ public class gg/essential/elementa/components/UIShape : gg/essential/elementa/UI
 
 public class gg/essential/elementa/components/UIText : gg/essential/elementa/UIComponent {
 	public fun <init> ()V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Z)V
 	public fun <init> (Ljava/lang/String;ZLjava/awt/Color;)V
@@ -665,7 +667,8 @@ public class gg/essential/elementa/components/UIText : gg/essential/elementa/UIC
 	public fun draw (Lgg/essential/universal/UMatrixStack;)V
 	public fun getHeight ()F
 	public final fun getShadow ()Z
-	public final fun getShadowColor ()Lgg/essential/elementa/state/State;
+	public final synthetic fun getShadowColor ()Lgg/essential/elementa/state/State;
+	public final fun getShadowColor ()Ljava/awt/Color;
 	public final fun getText ()Ljava/lang/String;
 	public final fun getTextWidth ()F
 	public fun getWidth ()F
@@ -676,6 +679,12 @@ public class gg/essential/elementa/components/UIText : gg/essential/elementa/UIC
 
 public class gg/essential/elementa/components/UIWrappedText : gg/essential/elementa/UIComponent {
 	public fun <init> ()V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Z)V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ZZ)V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ZZF)V
+	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ZZFLjava/lang/String;)V
+	public synthetic fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ZZFLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Z)V
 	public fun <init> (Ljava/lang/String;ZLjava/awt/Color;)V
@@ -689,7 +698,8 @@ public class gg/essential/elementa/components/UIWrappedText : gg/essential/eleme
 	public final fun bindText (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/components/UIWrappedText;
 	public fun draw (Lgg/essential/universal/UMatrixStack;)V
 	public final fun getShadow ()Z
-	public final fun getShadowColor ()Lgg/essential/elementa/state/State;
+	public final synthetic fun getShadowColor ()Lgg/essential/elementa/state/State;
+	public final fun getShadowColor ()Ljava/awt/Color;
 	public final fun getText ()Ljava/lang/String;
 	public final fun getTextWidth ()F
 	public final fun setShadow (Z)Lgg/essential/elementa/components/UIWrappedText;

--- a/src/main/kotlin/gg/essential/elementa/components/GradientComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/GradientComponent.kt
@@ -1,6 +1,7 @@
 package gg.essential.elementa.components
 
 import gg.essential.elementa.state.BasicState
+import gg.essential.elementa.state.MappedState
 import gg.essential.elementa.state.State
 import gg.essential.universal.UGraphics
 import gg.essential.universal.UMatrixStack
@@ -11,21 +12,28 @@ import java.awt.Color
  * Variant of [UIBlock] with two colours that fade into each other in a
  * gradient pattern.
  */
-open class GradientComponent @JvmOverloads constructor(
-    startColor: Color = Color.WHITE,
-    endColor: Color = Color.WHITE,
-    direction: GradientDirection = GradientDirection.TOP_TO_BOTTOM
+open class GradientComponent constructor(
+    startColor: State<Color>,
+    endColor: State<Color>,
+    direction: State<GradientDirection>
 ) : UIBlock(Color(0, 0, 0, 0)) {
-    private var startColorState: State<Color> = BasicState(startColor)
-    private var endColorState: State<Color> = BasicState(endColor)
-    private var directionState: State<GradientDirection> = BasicState(direction)
+
+    @JvmOverloads constructor(
+        startColor: Color = Color.WHITE,
+        endColor: Color = Color.WHITE,
+        direction: GradientDirection = GradientDirection.TOP_TO_BOTTOM
+    ): this(BasicState(startColor), BasicState(endColor), BasicState(direction))
+
+    private val startColorState: MappedState<Color, Color> = startColor.map { it }
+    private val endColorState: MappedState<Color, Color> = endColor.map{ it }
+    private val directionState: MappedState<GradientDirection, GradientDirection> = direction.map { it }
 
     fun getStartColor(): Color = startColorState.get()
     fun setStartColor(startColor: Color) = apply {
         startColorState.set(startColor)
     }
     fun bindStartColor(newStartColorState: State<Color>) = apply {
-        startColorState = newStartColorState
+        startColorState.rebind(newStartColorState)
     }
 
     fun getEndColor(): Color = endColorState.get()
@@ -33,7 +41,7 @@ open class GradientComponent @JvmOverloads constructor(
         endColorState.set(endColor)
     }
     fun bindEndColor(newEndColorState: State<Color>) = apply {
-        endColorState = newEndColorState
+        endColorState.rebind(newEndColorState)
     }
 
     fun getDirection(): GradientDirection = directionState.get()
@@ -41,7 +49,7 @@ open class GradientComponent @JvmOverloads constructor(
         directionState.set(direction)
     }
     fun bindDirection(newDirectionState: State<GradientDirection>) = apply {
-        directionState = newDirectionState
+        directionState.rebind(newDirectionState)
     }
 
     override fun drawBlock(matrixStack: UMatrixStack, x: Double, y: Double, x2: Double, y2: Double) {

--- a/src/main/kotlin/gg/essential/elementa/components/UIText.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIText.kt
@@ -16,7 +16,12 @@ import java.awt.Color
  * Simple text component that draws its given `text` at the scale determined by
  * this component's width & height constraints.
  */
-open class UIText constructor(text: State<String>, shadow: State<Boolean>, shadowColor: State<Color?>) : UIComponent() {
+open class UIText
+constructor(
+    text: State<String>,
+    shadow: State<Boolean> = BasicState(true),
+    shadowColor: State<Color?> = BasicState(null)
+) : UIComponent() {
     @JvmOverloads constructor(
         text: String = "",
         shadow: Boolean = true,

--- a/src/main/kotlin/gg/essential/elementa/components/UIText.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIText.kt
@@ -5,6 +5,7 @@ import gg.essential.elementa.UIConstraints
 import gg.essential.elementa.constraints.CenterConstraint
 import gg.essential.elementa.dsl.width
 import gg.essential.elementa.state.BasicState
+import gg.essential.elementa.state.MappedState
 import gg.essential.elementa.state.State
 import gg.essential.elementa.state.pixels
 import gg.essential.universal.UGraphics
@@ -15,14 +16,16 @@ import java.awt.Color
  * Simple text component that draws its given `text` at the scale determined by
  * this component's width & height constraints.
  */
-open class UIText @JvmOverloads constructor(
-    text: String = "",
-    shadow: Boolean = true,
-    shadowColor: Color? = null
-) : UIComponent() {
-    private val textState = BasicState(text).map { it } // extra map so we can easily rebind it
-    private var shadowState: State<Boolean> = BasicState(shadow)
-    private var shadowColorState: State<Color?> = BasicState(shadowColor)
+open class UIText constructor(text: State<String>, shadow: State<Boolean>, shadowColor: State<Color?>) : UIComponent() {
+    @JvmOverloads constructor(
+        text: String = "",
+        shadow: Boolean = true,
+        shadowColor: Color? = null
+    ) : this(BasicState(text), BasicState(shadow), BasicState(shadowColor))
+
+    private val textState: MappedState<String, String> = text.map { it } // extra map so we can easily rebind it
+    private val shadowState: MappedState<Boolean, Boolean> = shadow.map { it }
+    private val shadowColorState: MappedState<Color?, Color?> = shadowColor.map { it }
     private val textScaleState = constraints.asState { getTextScale() }
     /** Guess on whether we should be trying to center or top-align this component. See [BELOW_LINE_HEIGHT]. */
     private val verticallyCenteredState = constraints.asState { y is CenterConstraint }
@@ -54,11 +57,11 @@ open class UIText @JvmOverloads constructor(
     }
 
     fun bindShadow(newShadowState: State<Boolean>) = apply {
-        this.shadowState = newShadowState
+        shadowState.rebind(newShadowState)
     }
 
     fun bindShadowColor(newShadowColorState: State<Color?>) = apply {
-        this.shadowColorState = newShadowColorState
+        shadowColorState.rebind(newShadowColorState)
     }
 
     fun getText() = textState.get()
@@ -67,7 +70,11 @@ open class UIText @JvmOverloads constructor(
     fun getShadow() = shadowState.get()
     fun setShadow(shadow: Boolean) = apply { shadowState.set(shadow) }
 
-    fun getShadowColor() = shadowColorState
+    @Deprecated("Wrong return type", level = DeprecationLevel.HIDDEN)
+    @JvmName("getShadowColor")
+    fun getShadowColorState(): State<Color?> = shadowColorState
+
+    fun getShadowColor(): Color? = shadowColorState.get()
     fun setShadowColor(shadowColor: Color?) = apply { shadowColorState.set(shadowColor) }
 
     /**

--- a/src/main/kotlin/gg/essential/elementa/components/UIWrappedText.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIWrappedText.kt
@@ -21,8 +21,8 @@ import java.awt.Color
  */
 open class UIWrappedText @JvmOverloads constructor(
     text: State<String>,
-    shadow: State<Boolean>,
-    shadowColor: State<Color?>,
+    shadow: State<Boolean> = BasicState(true),
+    shadowColor: State<Color?> = BasicState(null),
     private var centered: Boolean = false,
     /**
      * Keeps the rendered text within the bounds of the component,

--- a/src/main/kotlin/gg/essential/elementa/components/input/UIPasswordInput.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/input/UIPasswordInput.kt
@@ -3,6 +3,8 @@ package gg.essential.elementa.components.input
 import gg.essential.elementa.dsl.pixels
 import gg.essential.elementa.dsl.width
 import gg.essential.elementa.state.BasicState
+import gg.essential.elementa.state.MappedState
+import gg.essential.elementa.state.State
 import java.awt.Color
 
 open class UIPasswordInput @JvmOverloads constructor(
@@ -25,7 +27,7 @@ open class UIPasswordInput @JvmOverloads constructor(
     inactiveSelectionForegroundColor,
     cursorColor
 ) {
-    private var protected: BasicState<Boolean> = BasicState(true)
+    private val protected: MappedState<Boolean, Boolean> = BasicState(true).map { it }
     private val passwordCharAsString: String = passwordChar.toString()
 
     override fun getTextForRender(): String = if (protected.get()) getProtectedString(getText()) else getText()
@@ -42,7 +44,7 @@ open class UIPasswordInput @JvmOverloads constructor(
     }
 
     fun bindProtection(protectedState: BasicState<Boolean>) = apply {
-        protected = protectedState
+        protected.rebind(protectedState)
     }
 
     fun isProtected(): Boolean = protected.get()

--- a/src/main/kotlin/gg/essential/elementa/constraints/ColorConstraints.kt
+++ b/src/main/kotlin/gg/essential/elementa/constraints/ColorConstraints.kt
@@ -5,6 +5,7 @@ import gg.essential.elementa.constraints.resolution.ConstraintVisitor
 import gg.essential.elementa.state.BasicState
 import gg.essential.elementa.state.State
 import gg.essential.elementa.dsl.*
+import gg.essential.elementa.state.MappedState
 import java.awt.Color
 import kotlin.math.sin
 import kotlin.random.Random
@@ -12,19 +13,20 @@ import kotlin.random.Random
 /**
  * Sets the color to be a constant, determined color.
  */
-class ConstantColorConstraint(color: Color = Color.WHITE) : ColorConstraint {
+class ConstantColorConstraint(color: State<Color>) : ColorConstraint {
+    @JvmOverloads constructor(color: Color = Color.WHITE) : this(BasicState(color))
     override var cachedValue: Color = Color.WHITE
     override var recalculate = true
     override var constrainTo: UIComponent? = null
 
-    private var colorState: State<Color> = BasicState(color)
+    private val colorState: MappedState<Color, Color> = color.map { it }
 
     var color: Color
         get() = colorState.get()
         set(value) { colorState.set(value) }
 
     fun bindColor(newState: State<Color>) = apply {
-        colorState = newState
+        colorState.rebind(newState)
     }
 
     override fun getColorImpl(component: UIComponent): Color {
@@ -43,13 +45,15 @@ class ConstantColorConstraint(color: Color = Color.WHITE) : ColorConstraint {
 /**
  * Sets the color to be constant but with an alpha based off of its parent.
  */
-class AlphaAspectColorConstraint(color: Color = Color.WHITE, alphaValue: Float = 1f) : ColorConstraint {
+class AlphaAspectColorConstraint(color: State<Color>, alphaValue: State<Float>) : ColorConstraint {
+    constructor(color: Color = Color.WHITE, alphaValue: Float = 1f) : this(BasicState(color), BasicState(alphaValue))
+    constructor() : this(Color.WHITE, 1f)
     override var cachedValue: Color = Color.WHITE
     override var recalculate = true
     override var constrainTo: UIComponent? = null
 
-    private var colorState: State<Color> = BasicState(color)
-    private var alphaState: State<Float> = BasicState(alphaValue)
+    private val colorState: MappedState<Color, Color> = color.map { it }
+    private val alphaState: MappedState<Float, Float> = alphaValue.map { it }
 
     var color: Color
         get() = colorState.get()
@@ -59,11 +63,11 @@ class AlphaAspectColorConstraint(color: Color = Color.WHITE, alphaValue: Float =
         set(value) { alphaState.set(value) }
 
     fun bindColor(newState: State<Color>) = apply {
-        colorState = newState
+        colorState.rebind(newState)
     }
 
     fun bindAlpha(newState: State<Float>) = apply {
-        alphaState = newState
+        alphaState.rebind(newState)
     }
 
     override fun getColorImpl(component: UIComponent): Color {

--- a/src/main/kotlin/gg/essential/elementa/constraints/PixelConstraint.kt
+++ b/src/main/kotlin/gg/essential/elementa/constraints/PixelConstraint.kt
@@ -3,6 +3,7 @@ package gg.essential.elementa.constraints
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.constraints.resolution.ConstraintVisitor
 import gg.essential.elementa.state.BasicState
+import gg.essential.elementa.state.MappedState
 import gg.essential.elementa.state.State
 
 /**
@@ -10,17 +11,22 @@ import gg.essential.elementa.state.State
  * number of pixels.
  */
 class PixelConstraint @JvmOverloads constructor(
-    value: Float,
-    alignOpposite: Boolean = false,
-    alignOutside:  Boolean = false
+    value: State<Float>,
+    alignOpposite: State<Boolean> = BasicState(false),
+    alignOutside: State<Boolean> = BasicState(false)
 ) : MasterConstraint {
+    @JvmOverloads constructor(
+        value: Float,
+        alignOpposite: Boolean = false,
+        alignOutside: Boolean = false
+    ) : this(BasicState(value), BasicState(alignOpposite), BasicState(alignOutside))
     override var cachedValue = 0f
     override var recalculate = true
     override var constrainTo: UIComponent? = null
 
-    private var valueState: State<Float> = BasicState(value)
-    private var alignOppositeState: State<Boolean> = BasicState(alignOpposite)
-    private var alignOutsideState: State<Boolean> = BasicState(alignOutside)
+    private val valueState: MappedState<Float, Float> = value.map { it }
+    private val alignOppositeState: MappedState<Boolean, Boolean> = alignOpposite.map { it }
+    private val alignOutsideState: MappedState<Boolean, Boolean> = alignOutside.map { it }
 
     var value: Float
         get() = valueState.get()
@@ -33,15 +39,15 @@ class PixelConstraint @JvmOverloads constructor(
         set(value) { alignOutsideState.set(value) }
 
     fun bindValue(newState: State<Float>) = apply {
-        valueState = newState
+        valueState.rebind(newState)
     }
 
     fun bindAlignOpposite(newState: State<Boolean>) = apply {
-        alignOppositeState = newState
+        alignOppositeState.rebind(newState)
     }
 
     fun bindAlignOutside(newState: State<Boolean>) = apply {
-        alignOutsideState = newState
+        alignOutsideState.rebind(newState)
     }
 
     override fun getXPositionImpl(component: UIComponent): Float {

--- a/src/main/kotlin/gg/essential/elementa/constraints/RelativeConstraint.kt
+++ b/src/main/kotlin/gg/essential/elementa/constraints/RelativeConstraint.kt
@@ -10,12 +10,13 @@ import gg.essential.elementa.state.State
  * Sets this component's X/Y position or width/height to be some
  * multiple of its parents.
  */
-class RelativeConstraint @JvmOverloads constructor(value: Float = 1f) : PositionConstraint, SizeConstraint {
+class RelativeConstraint constructor(value: State<Float>) : PositionConstraint, SizeConstraint {
+    @JvmOverloads constructor(value: Float = 1f) : this(BasicState(value))
     override var cachedValue = 0f
     override var recalculate = true
     override var constrainTo: UIComponent? = null
 
-    private val valueState: MappedState<Float, Float> = BasicState(value).map { it }
+    private val valueState: MappedState<Float, Float> = value.map { it }
 
     var value: Float
         get() = valueState.get()

--- a/src/main/kotlin/gg/essential/elementa/constraints/RelativeConstraint.kt
+++ b/src/main/kotlin/gg/essential/elementa/constraints/RelativeConstraint.kt
@@ -3,6 +3,7 @@ package gg.essential.elementa.constraints
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.constraints.resolution.ConstraintVisitor
 import gg.essential.elementa.state.BasicState
+import gg.essential.elementa.state.MappedState
 import gg.essential.elementa.state.State
 
 /**
@@ -14,14 +15,14 @@ class RelativeConstraint @JvmOverloads constructor(value: Float = 1f) : Position
     override var recalculate = true
     override var constrainTo: UIComponent? = null
 
-    private var valueState: State<Float> = BasicState(value)
+    private val valueState: MappedState<Float, Float> = BasicState(value).map { it }
 
     var value: Float
         get() = valueState.get()
         set(value) { valueState.set(value) }
 
     fun bindValue(newState: State<Float>) = apply {
-        valueState = newState
+        valueState.rebind(newState)
     }
 
     override fun getXPositionImpl(component: UIComponent): Float {

--- a/src/main/kotlin/gg/essential/elementa/constraints/ScaleConstraint.kt
+++ b/src/main/kotlin/gg/essential/elementa/constraints/ScaleConstraint.kt
@@ -3,20 +3,22 @@ package gg.essential.elementa.constraints
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.constraints.resolution.ConstraintVisitor
 import gg.essential.elementa.state.BasicState
+import gg.essential.elementa.state.MappedState
 import gg.essential.elementa.state.State
 
-class ScaleConstraint(val constraint: SuperConstraint<Float>, value: Float) : MasterConstraint {
+class ScaleConstraint(val constraint: SuperConstraint<Float>, value: State<Float>) : MasterConstraint {
+    constructor(constraint: SuperConstraint<Float>, value: Float) : this(constraint, BasicState(value))
     override var cachedValue = 0f
     override var recalculate = true
     override var constrainTo: UIComponent? = null
 
-    private var valueState: State<Float> = BasicState(value)
+    private val valueState: MappedState<Float, Float> = value.map { it }
     var value: Float
         get() = valueState.get()
         set(value) = valueState.set(value)
 
     fun bindValue(newState: State<Float>) = apply {
-        valueState = newState
+        valueState.rebind(newState)
     }
 
     override fun animationFrame() {

--- a/src/main/kotlin/gg/essential/elementa/effects/OutlineEffect.kt
+++ b/src/main/kotlin/gg/essential/elementa/effects/OutlineEffect.kt
@@ -2,6 +2,7 @@ package gg.essential.elementa.effects
 
 import gg.essential.elementa.components.UIBlock
 import gg.essential.elementa.state.BasicState
+import gg.essential.elementa.state.MappedState
 import gg.essential.elementa.state.State
 import gg.essential.universal.UMatrixStack
 import java.awt.Color
@@ -12,19 +13,27 @@ import java.awt.Color
  * so all children will render above the outline.
  */
 class OutlineEffect @JvmOverloads constructor(
-    color: Color,
-    width: Float,
+    color: State<Color>,
+    width: State<Float>,
     var drawAfterChildren: Boolean = false,
     var drawInsideChildren: Boolean = false,
     sides: Set<Side> = setOf(Side.Left, Side.Top, Side.Right, Side.Bottom)
 ) : Effect() {
+    @JvmOverloads constructor(
+        color: Color,
+        width: Float,
+        drawAfterChildren: Boolean = false,
+        drawInsideChildren: Boolean = false,
+        sides: Set<Side> = setOf(Side.Left, Side.Top, Side.Right, Side.Bottom)
+    ) : this(BasicState(color), BasicState(width), drawAfterChildren, drawInsideChildren, sides)
+
     private var hasLeft = Side.Left in sides
     private var hasTop = Side.Top in sides
     private var hasRight = Side.Right in sides
     private var hasBottom = Side.Bottom in sides
 
-    private var colorState: State<Color> = BasicState(color)
-    private var widthState: State<Float> = BasicState(width)
+    private val colorState: MappedState<Color, Color> = color.map { it }
+    private val widthState: MappedState<Float, Float> = width.map { it }
 
     var color: Color
         get() = colorState.get()
@@ -39,11 +48,11 @@ class OutlineEffect @JvmOverloads constructor(
         }
 
     fun bindColor(state: State<Color>) = apply {
-        colorState = state
+        colorState.rebind(state)
     }
 
     fun bindWidth(state: State<Float>) = apply {
-        widthState = state
+        widthState.rebind(state)
     }
 
     var sides = sides

--- a/src/main/kotlin/gg/essential/elementa/effects/RecursiveFadeEffect.kt
+++ b/src/main/kotlin/gg/essential/elementa/effects/RecursiveFadeEffect.kt
@@ -15,16 +15,10 @@ import kotlin.math.roundToInt
 /**
  * Fades a component's color as well as all of its children.
  */
-class RecursiveFadeEffect @JvmOverloads constructor(
+class RecursiveFadeEffect constructor(
     isOverridden: State<Boolean> = BasicState(false),
     overriddenAlphaPercentage: State<Float> = BasicState(1f)
 ) : Effect() {
-    constructor(
-        isOverridden: Boolean,
-        overriddenAlphaPercentage: Float
-    ) : this(BasicState(isOverridden), BasicState(overriddenAlphaPercentage))
-    constructor(isOverridden: Boolean = false) : this(isOverridden, 1f)
-    constructor(overriddenAlphaPercentage: Float = 1f) : this(false, overriddenAlphaPercentage)
     private val isOverridden: MappedState<Boolean, Boolean> = isOverridden.map { it }
     private val overriddenAlphaPercentage: MappedState<Float, Float> = overriddenAlphaPercentage.map { it }
 

--- a/src/main/kotlin/gg/essential/elementa/effects/RecursiveFadeEffect.kt
+++ b/src/main/kotlin/gg/essential/elementa/effects/RecursiveFadeEffect.kt
@@ -5,8 +5,8 @@ import gg.essential.elementa.constraints.ColorConstraint
 import gg.essential.elementa.constraints.ConstraintType
 import gg.essential.elementa.constraints.resolution.ConstraintVisitor
 import gg.essential.elementa.dsl.constrain
-import gg.essential.elementa.effects.Effect
 import gg.essential.elementa.state.BasicState
+import gg.essential.elementa.state.MappedState
 import gg.essential.elementa.state.State
 import gg.essential.elementa.utils.withAlpha
 import java.awt.Color
@@ -15,16 +15,25 @@ import kotlin.math.roundToInt
 /**
  * Fades a component's color as well as all of its children.
  */
-class RecursiveFadeEffect(
-    private var isOverridden: State<Boolean> = BasicState(false),
-    private var overriddenAlphaPercentage: State<Float> = BasicState(1f)
+class RecursiveFadeEffect @JvmOverloads constructor(
+    isOverridden: State<Boolean> = BasicState(false),
+    overriddenAlphaPercentage: State<Float> = BasicState(1f)
 ) : Effect() {
+    constructor(
+        isOverridden: Boolean,
+        overriddenAlphaPercentage: Float
+    ) : this(BasicState(isOverridden), BasicState(overriddenAlphaPercentage))
+    constructor(isOverridden: Boolean = false) : this(isOverridden, 1f)
+    constructor(overriddenAlphaPercentage: Float = 1f) : this(false, overriddenAlphaPercentage)
+    private val isOverridden: MappedState<Boolean, Boolean> = isOverridden.map { it }
+    private val overriddenAlphaPercentage: MappedState<Float, Float> = overriddenAlphaPercentage.map { it }
+
     fun rebindIsOverridden(state: State<Boolean>) = apply {
-        isOverridden = state
+        isOverridden.rebind(state)
     }
 
     fun rebindOverriddenAlphaPercentage(state: State<Float>) = apply {
-        overriddenAlphaPercentage = state
+        overriddenAlphaPercentage.rebind(state)
     }
 
     override fun setup() {


### PR DESCRIPTION
Previously, state fields were mutable and reassigned when rebound which caused potentially undesired behavior. These commits change those fields from being mutable to immutable mapped states which are rebound to the new state value.

Fixes [EM-420](https://linear.app/sparkuniverse/issue/EM-420)