### PR TITLE
Build: Fix internal dependencies not being available in dev

### DIFF
--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin")
     }
 
-    common(project(":")) { isTransitive = false }
+    common(project(":"))
 
     if (platform.isFabric) {
         val fabricApiVersion = when(platform.mcVersion) {


### PR DESCRIPTION
Internal dependencies used to be added directly to the project's classpath and
its jar but that means that dependent projects did not inherit it. As such it
wasn't possible to run e.g. 1.12.2 in dev because the relocated internal
dependencies were not on its classpath.

This commit changes that such that the internal dependencies jar is now a
regular dependency of the common project and as a result it's inherited by the
platform projects.
That would however result in the internal dependencies being bundled twice (once
in the common jar, and then a second time in the platform jar), so we skip the
first one by no longer using the `makeConfigurationForInternalDependencies`
method.
We also change the Kotlin dependencies in the common project to be
`compileOnly`, so they are not inherited by the platform project, which needs to
re-declare them for maven anyway.