### PR TITLE
Fix/markdown list drawable

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/MarkdownNode.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/MarkdownNode.kt
@@ -1,0 +1,28 @@
+package gg.essential.elementa.components
+
+import gg.essential.elementa.components.inspector.ArrowComponent
+import gg.essential.elementa.constraints.SiblingConstraint
+import gg.essential.elementa.dsl.constrain
+import gg.essential.elementa.dsl.pixels
+import gg.essential.elementa.markdown.drawables.Drawable
+import gg.essential.elementa.markdown.drawables.TextDrawable
+
+internal class MarkdownNode(private val targetDrawable: Drawable) : TreeNode() {
+    private val componentClassName = targetDrawable.javaClass.simpleName.ifEmpty { "UnknownType" }
+    private val componentDisplayName =
+        componentClassName + if (targetDrawable is TextDrawable) " \"${targetDrawable.formattedText}\"" else ""
+
+    private val component = UIText(componentDisplayName).constrain {
+        x = SiblingConstraint()
+        y = 2.pixels
+    }
+
+    init {
+        targetDrawable.children.forEach {
+            addChild(MarkdownNode(it))
+        }
+    }
+    override fun getArrowComponent() = ArrowComponent(targetDrawable.children.isEmpty())
+
+    override fun getPrimaryComponent() = component
+}

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -173,6 +173,9 @@ class MarkdownComponent(
     }
 
     override fun draw(matrixStack: UMatrixStack) {
+        if (needsInitialLayout) {
+            animationFrame()
+        }
         beforeDraw(matrixStack)
 
         val drawState = DrawState(getLeft() - baseX, getTop() - baseY)

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -1,6 +1,9 @@
 package gg.essential.elementa.markdown
 
 import gg.essential.elementa.UIComponent
+import gg.essential.elementa.components.MarkdownNode
+import gg.essential.elementa.components.TreeListComponent
+import gg.essential.elementa.components.TreeNode
 import gg.essential.elementa.components.Window
 import gg.essential.elementa.constraints.HeightConstraint
 import gg.essential.elementa.dsl.pixels
@@ -18,9 +21,6 @@ import gg.essential.elementa.utils.elementaDebug
 import gg.essential.universal.UDesktop
 import gg.essential.universal.UKeyboard
 import gg.essential.universal.UMatrixStack
-import java.awt.Color
-import kotlin.math.PI
-import kotlin.math.sin
 
 /**
  * Component that parses a string as Markdown and renders it.
@@ -170,6 +170,18 @@ class MarkdownComponent(
         if (currentValues != lastValues)
             layout()
         lastValues = currentValues
+    }
+
+    /**
+     * Returns a [TreeListComponent] that contains the markdown tree.
+     */
+    internal fun createLayoutTree(): TreeListComponent {
+        val nodes = mutableListOf<TreeNode>()
+        drawables.forEach {
+            nodes.add(MarkdownNode(it))
+        }
+
+        return TreeListComponent(nodes)
     }
 
     override fun draw(matrixStack: UMatrixStack) {

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ListDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ListDrawable.kt
@@ -88,23 +88,9 @@ class ListDrawable(
             currY += elementSpacing
         }
 
-        for (drawable_ in drawables) {
-            var drawable = drawable_
+        for (drawable in drawables) {
             if (drawable is ListDrawable)
                 drawable.indentLevel = indentLevel + 1
-            if (drawable is DrawableList) {
-                // Pull out any trailing ListDrawables into their own ListElement
-                val last = drawable.last()
-                if (last is ListDrawable) {
-                    drawable = DrawableList(md, drawable.dropLast(1))
-                    addItem(drawable)
-                    index++
-                    orderedListShift++
-                    trim(last)
-                    last.isLoose = isLoose
-                    drawable = last
-                }
-            }
             addItem(drawable)
             index++
         }

--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin")
     }
 
-    common(project(":")) { isTransitive = false }
+    common(project(":"))
 
     if (platform.isFabric) {
         val fabricApiVersion = when(platform.mcVersion) {


### PR DESCRIPTION
This PR fixes two bugs in the impl of MarkdownComponent. 

1. MarkdownComponent requires its layout to be calculated before it can be rendered. The component's initial layout is configured in the first call to `animationFrame()`. However, this is not necessary before the first call to draw, leading to an uncaught exception in the case `draw` is called first. The fix in this PR calls `animationFrame()` if the component has not performed its initial layout calculation at the time of draw.
2. `ListDrawable` attempted to slightly simplify the layout tree. This unnecessary behavior led to elements of `ListDrawable` not having their layout configured because they are bypassed when calculating the tree. The PR removes that simplification so that the layout structure correctly matches the full layout tree.
