### PR TITLE
Fix/arrow component svg reparsing

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/inspector/ArrowComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/inspector/ArrowComponent.kt
@@ -2,43 +2,55 @@ package gg.essential.elementa.components.inspector
 
 import gg.essential.elementa.components.SVGComponent
 import gg.essential.elementa.components.TreeArrowComponent
+import gg.essential.elementa.constraints.ChildBasedSizeConstraint
 import gg.essential.elementa.dsl.childOf
 import gg.essential.elementa.dsl.constrain
 import gg.essential.elementa.dsl.pixels
+import gg.essential.elementa.svg.SVGParser
 import gg.essential.universal.UMatrixStack
 
 class ArrowComponent(private val empty: Boolean) : TreeArrowComponent() {
-    private val closedIcon = SVGComponent.ofResource("/svg/square-plus.svg").constrain {
-        width = 10.pixels()
-        height = 10.pixels()
+    private val closedIcon = SVGComponent(closedSvg).constrain {
+        width = 10.pixels
+        height = 10.pixels
     }
-    private val openIcon = SVGComponent.ofResource("/svg/square-minus.svg").constrain {
-        width = 10.pixels()
-        height = 10.pixels()
+    private val openIcon = SVGComponent(openSvg).constrain {
+        width = 10.pixels
+        height = 10.pixels
     }
 
     init {
         constrain {
-            width = 10.pixels()
-            height = 10.pixels()
+            width = ChildBasedSizeConstraint()
+            height = ChildBasedSizeConstraint()
         }
 
-        if (!empty)
+        if (!empty) {
             closedIcon childOf this
+        }
     }
 
     override fun open() {
-        if (!empty)
+        if (!empty) {
             replaceChild(openIcon, closedIcon)
+        }
     }
 
     override fun close() {
-        if (!empty)
+        if (!empty) {
             replaceChild(closedIcon, openIcon)
+        }
     }
 
     override fun draw(matrixStack: UMatrixStack) {
         beforeDraw(matrixStack)
         super.draw(matrixStack)
+    }
+
+    companion object {
+
+        private val closedSvg = SVGParser.parseFromResource("/svg/square-plus.svg")
+        private val openSvg = SVGParser.parseFromResource("/svg/square-minus.svg")
+
     }
 }

--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin")
     }
 
-    common(project(":")) { isTransitive = false }
+    common(project(":"))
 
     if (platform.isFabric) {
         val fabricApiVersion = when(platform.mcVersion) {


### PR DESCRIPTION
Cache SVG data instead of parsing for each component. 

The ArrowComponent previously read and parsed the open and close SVG each time an instance is created. This severely degraded the performance of the inspector whenever the layout changed. The component now parses each SVG once, and caches the result for any time it is needed.

Depends on #69 