### PR TITLE
ScrollComponent: Fix scrollbar position when scroll direction is inverted

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -421,7 +421,7 @@ class ScrollComponent @JvmOverloads constructor(
                     Animations.IN_SIN, 0.1f, basicXConstraint { component ->
                         val offset = (component.parent.getWidth() - component.getWidth()) * scrollPercentage
 
-                        if (horizontalScrollOpposite) component.parent.getRight() - component.getHeight() - offset
+                        if (horizontalScrollOpposite) component.parent.getRight() - component.getHeight() + offset
                         else component.parent.getLeft() + offset
                     }
                 )
@@ -430,7 +430,7 @@ class ScrollComponent @JvmOverloads constructor(
                     Animations.IN_SIN, 0.1f, basicYConstraint { component ->
                         val offset = (component.parent.getHeight() - component.getHeight()) * scrollPercentage
 
-                        if (verticalScrollOpposite) component.parent.getBottom() - component.getHeight() - offset
+                        if (verticalScrollOpposite) component.parent.getBottom() - component.getHeight() + offset
                         else component.parent.getTop() + offset
                     }
                 )


### PR DESCRIPTION
This PR fixes the scrollbar position when `verticalScrollOpposite` or `horizontalScrollOpposite` are set to true. 