### PR TITLE
EM-708 - Adjust Markdown wrapping to avoid extra whitespace

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3511,7 +3511,9 @@ public final class gg/essential/elementa/markdown/drawables/HeaderDrawable : gg/
 	public fun cursorAtStart ()Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun draw (Lgg/essential/universal/UMatrixStack;Lgg/essential/elementa/markdown/DrawState;)V
 	public fun getChildren ()Ljava/util/List;
+	public final fun getDividerWidth ()Ljava/lang/Double;
 	public fun selectedText (Z)Ljava/lang/String;
+	public final fun setDividerWidth (Ljava/lang/Double;)V
 }
 
 public final class gg/essential/elementa/markdown/drawables/ImageDrawable : gg/essential/elementa/markdown/drawables/Drawable {

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3159,6 +3159,7 @@ public final class gg/essential/elementa/markdown/MarkdownComponent : gg/essenti
 	public fun draw (Lgg/essential/universal/UMatrixStack;)V
 	public final fun getConfig ()Lgg/essential/elementa/markdown/MarkdownConfig;
 	public final fun getDrawables ()Lgg/essential/elementa/markdown/drawables/DrawableList;
+	public final fun getMaxTextLineWidth ()F
 	public final fun getSectionOffsets ()Ljava/util/Map;
 	public final fun layout ()V
 	public final fun onLinkClicked (Lkotlin/jvm/functions/Function2;)V
@@ -3319,6 +3320,7 @@ public final class gg/essential/elementa/markdown/drawables/BlockquoteDrawable :
 	public fun draw (Lgg/essential/universal/UMatrixStack;Lgg/essential/elementa/markdown/DrawState;)V
 	public fun getChildren ()Ljava/util/List;
 	public final fun getDrawables ()Lgg/essential/elementa/markdown/drawables/DrawableList;
+	public final fun getMaxTextLineWidth ()F
 	public fun selectedText (Z)Ljava/lang/String;
 }
 
@@ -3545,6 +3547,7 @@ public final class gg/essential/elementa/markdown/drawables/ListDrawable : gg/es
 	public fun cursorAtStart ()Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun draw (Lgg/essential/universal/UMatrixStack;Lgg/essential/elementa/markdown/DrawState;)V
 	public fun getChildren ()Ljava/util/List;
+	public final fun getMaxTextLineWidth ()F
 	public fun selectedText (Z)Ljava/lang/String;
 }
 
@@ -3567,6 +3570,7 @@ public final class gg/essential/elementa/markdown/drawables/ParagraphDrawable : 
 	public fun draw (Lgg/essential/universal/UMatrixStack;Lgg/essential/elementa/markdown/DrawState;)V
 	public fun getChildren ()Ljava/util/List;
 	public final fun getDrawables ()Lgg/essential/elementa/markdown/drawables/DrawableList;
+	public final fun getMaxTextLineWidth ()F
 	public final fun getScaleModifier ()F
 	public final fun getTextDrawables ()Ljava/util/List;
 	public fun selectedText (Z)Ljava/lang/String;

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/BlockquoteDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/BlockquoteDrawable.kt
@@ -3,12 +3,14 @@ package gg.essential.elementa.markdown.drawables
 import gg.essential.elementa.components.UIBlock
 import gg.essential.elementa.markdown.DrawState
 import gg.essential.elementa.markdown.MarkdownComponent
-import gg.essential.elementa.markdown.MarkdownConfig
 import gg.essential.universal.UMatrixStack
 
 class BlockquoteDrawable(md: MarkdownComponent, val drawables: DrawableList) : Drawable(md) {
     private var dividerHeight: Float = -1f
     override val children: List<Drawable> get() = drawables
+
+    var maxTextLineWidth = 0f
+        private set
 
     init {
         drawables.parent = this
@@ -38,6 +40,10 @@ class BlockquoteDrawable(md: MarkdownComponent, val drawables: DrawableList) : D
             currY += config.spaceAfterBlockquote
 
         val height = currY - y
+
+        maxTextLineWidth = drawables.maxOfOrNull { drawable ->
+            (drawable as? ParagraphDrawable)?.maxTextLineWidth?.plus(padding) ?: 0f
+        } ?: 0f
 
         return Layout(
             x,

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/HeaderDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/HeaderDrawable.kt
@@ -13,6 +13,8 @@ class HeaderDrawable(
     override val children: List<Drawable> get() = listOf(paragraph)
     internal val id = paragraph.textDrawables.joinToString(separator = " ") { it.plainText() }
 
+    var dividerWidth: Double? = null
+
     init {
         paragraph.parent = this
     }
@@ -60,7 +62,7 @@ class HeaderDrawable(
                 headerConfig.dividerColor, 
                 (x + state.xShift).toDouble(),
                 (y + state.yShift).toDouble(),
-                width.toDouble(),
+                dividerWidth ?: width.toDouble(),
                 headerConfig.dividerWidth.toDouble()
             )
         }

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ListDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ListDrawable.kt
@@ -33,6 +33,10 @@ class ListDrawable(
      */
     private var indentLevel = 0
 
+    // The width of the longest list entry, including the indentation, symbol width, and space after symbol
+    var maxTextLineWidth = 0f
+        private set
+
     init {
         trim(drawables)
         drawables.parent = this
@@ -94,6 +98,12 @@ class ListDrawable(
             addItem(drawable)
             index++
         }
+
+        maxTextLineWidth = drawables.maxOfOrNull { drawable ->
+            drawable.children.filterIsInstance<ParagraphDrawable>().maxOfOrNull {
+                indentation + symbolWidth + spaceAfterSymbol + it.maxTextLineWidth
+            } ?: 0f
+        } ?: 0f
 
         currY -= elementSpacing
         currY += marginBottom

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -80,7 +80,11 @@ class ParagraphDrawable(
         val currentLine = mutableListOf<Drawable>()
         var maxLineHeight = Float.MIN_VALUE
 
+        var prevY = y
+
         fun gotoNextLine() {
+            prevY = currY
+
             currX = x
             currY += maxLineHeight * scaleModifier + config.paragraphConfig.spaceBetweenLines
 
@@ -261,9 +265,8 @@ class ParagraphDrawable(
 
         drawables.setDrawables(newDrawables)
 
-        val height = currY - y + 9f * scaleModifier + if (insertSpaceAfter) {
-            config.paragraphConfig.spaceAfter
-        } else 0f
+        val height = (if (currentLine.isNotEmpty()) currY else prevY) - y + 9f * scaleModifier +
+                if (insertSpaceAfter) config.paragraphConfig.spaceAfter else 0f
 
         return Layout(
             x,

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -29,6 +29,10 @@ class ParagraphDrawable(
     val textDrawables: List<TextDrawable>
         get() = children.filterIsInstance<TextDrawable>()
 
+    // The width of the longest TextDrawable line after lines are split
+    var maxTextLineWidth = 0f
+        private set
+
     // Used by HeaderDrawable
     internal var headerConfig: HeaderLevelConfig? = null
         set(value) {
@@ -245,6 +249,10 @@ class ParagraphDrawable(
                 }
             }
         }
+
+        maxTextLineWidth = lines.maxOfOrNull { line ->
+            line.sumOf { (it as? TextDrawable)?.width()?.toDouble() ?: it.width.toDouble() }.toFloat()
+        } ?: 0f
 
         newDrawables.forEach {
             if (it is TextDrawable)

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
@@ -71,39 +71,44 @@ class TextDrawable(
     fun split(maxWidth: Float, breakWords: Boolean = false): Pair<TextDrawable, TextDrawable>? {
         val styleChars = style.numFormattingChars
         val plainText = plainText()
-        if (plainText.length <= 1)
+
+        if (plainText.length <= 1) {
             return null
+        }
 
         var splitPoint = formattedText.indices.drop(styleChars).firstOrNull {
             formattedText.substring(0, it + 1).width(scaleModifier) > maxWidth
-        }
-
-        if (splitPoint == null)
-            throw IllegalStateException("TextDrawable#split called when it should not have been called")
+        } ?: throw IllegalStateException("TextDrawable#split called when it should not have been called")
 
         splitPoint = splitPoint - 1 - styleChars
 
         if (!breakWords) {
-            while (splitPoint > styleChars && formattedText[splitPoint - 1] != ' ')
+            while (splitPoint > styleChars && formattedText[splitPoint - 1] != ' ') {
                 splitPoint--
+            }
 
-            if (splitPoint == styleChars)
+            if (splitPoint == styleChars) {
                 return null
+            }
         }
-        if (splitPoint <= 0)
+
+        if (splitPoint <= 0) {
             splitPoint = 1
+        }
+
         val first = TextDrawable(md, plainText.substring(0, splitPoint).trimEnd(), style)
         val second = TextDrawable(md, plainText.substring(splitPoint, plainText.length), style)
 
         val linkedTexts = this.linkedTexts?.also {
             // We are splitting this text drawable, so in effect this
             // drawable no longer "exists", because it isn't relevant.
-            // Therefore we remove it from this linked text group
+            // Therefore, we remove it from this linked text group
             it.unlinkText(this)
         } ?: LinkedTexts()
 
         linkedTexts.linkText(first)
         linkedTexts.linkText(second)
+
         first.linkedTexts = linkedTexts
         second.linkedTexts = linkedTexts
 

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
@@ -11,7 +11,6 @@ import gg.essential.elementa.markdown.MarkdownConfig
 import gg.essential.elementa.markdown.selection.TextCursor
 import gg.essential.universal.UMatrixStack
 import gg.essential.universal.UMouse
-import gg.essential.universal.UResolution
 import java.awt.Color
 
 class TextDrawable(
@@ -57,7 +56,7 @@ class TextDrawable(
 
         val styleChars = style.numFormattingChars
         formattedText = formattedText.substring(0, styleChars) +
-            formattedText.substring(styleChars, formattedText.length).trimStart()
+                formattedText.substring(styleChars, formattedText.length).trimStart()
     }
 
     fun width() = formattedText.width(scaleModifier) + if (style.isCode) {
@@ -93,7 +92,7 @@ class TextDrawable(
         }
         if (splitPoint <= 0)
             splitPoint = 1
-        val first = TextDrawable(md, plainText.substring(0, splitPoint), style)
+        val first = TextDrawable(md, plainText.substring(0, splitPoint).trimEnd(), style)
         val second = TextDrawable(md, plainText.substring(splitPoint, plainText.length), style)
 
         val linkedTexts = this.linkedTexts?.also {

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
@@ -80,10 +80,10 @@ class TextDrawable(
             formattedText.substring(0, it + 1).width(scaleModifier) > maxWidth
         } ?: throw IllegalStateException("TextDrawable#split called when it should not have been called")
 
-        splitPoint = splitPoint - 1 - styleChars
+        splitPoint -= styleChars
 
         if (!breakWords) {
-            while (splitPoint > styleChars && formattedText[splitPoint - 1] != ' ') {
+            while (splitPoint > styleChars && formattedText[splitPoint] != ' ') {
                 splitPoint--
             }
 


### PR DESCRIPTION
This PR aims to improve line wrapping in Markdown components such that the line width accurately represents the actual width of a line.
This should be useful in cases where a component's width is adjusted relative to a Markdown component's line width(s) without resulting in arbitrary trailing whitespace.