### PR TITLE
VanillaFontRenderer: Obey passed value of shadow when rendering text.

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/VanillaFontRenderer.kt
+++ b/src/main/kotlin/gg/essential/elementa/VanillaFontRenderer.kt
@@ -37,7 +37,7 @@ class VanillaFontRenderer : FontProvider {
         val scaledY = y.roundToRealPixels() / scale
 
         matrixStack.scale(scale, scale, 1f)
-        if (shadowColor == null) {
+        if (shadowColor == null || !shadow) {
             UGraphics.drawString(matrixStack, string, scaledX, scaledY, color.rgb, shadow)
         } else {
             UGraphics.drawString(matrixStack, string, scaledX, scaledY, color.rgb, shadowColor.rgb)


### PR DESCRIPTION
If shadowColor was supplied, the text was rendered with a shadow regardless of what the value of shadow was. This has been fixed.

Fixes EM-796