### PR TITLE
Introduce State v2

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -11,7 +11,7 @@ public final class gg/essential/elementa/ElementaVersion : java/lang/Enum {
 public final class gg/essential/elementa/ElementaVersion$Companion {
 }
 
-public abstract class gg/essential/elementa/UIComponent : java/util/Observable {
+public abstract class gg/essential/elementa/UIComponent : java/util/Observable, gg/essential/elementa/state/v2/ReferenceHolder {
 	public static final field Companion Lgg/essential/elementa/UIComponent$Companion;
 	public field parent Lgg/essential/elementa/UIComponent;
 	public fun <init> ()V
@@ -88,6 +88,7 @@ public abstract class gg/essential/elementa/UIComponent : java/util/Observable {
 	public final fun hide (Z)V
 	public static synthetic fun hide$default (Lgg/essential/elementa/UIComponent;ZILjava/lang/Object;)V
 	public fun hitTest (FF)Lgg/essential/elementa/UIComponent;
+	public fun holdOnto (Ljava/lang/Object;)Lkotlin/jvm/functions/Function0;
 	public fun insertChildAfter (Lgg/essential/elementa/UIComponent;Lgg/essential/elementa/UIComponent;)Lgg/essential/elementa/UIComponent;
 	public fun insertChildAt (Lgg/essential/elementa/UIComponent;I)Lgg/essential/elementa/UIComponent;
 	public fun insertChildBefore (Lgg/essential/elementa/UIComponent;Lgg/essential/elementa/UIComponent;)Lgg/essential/elementa/UIComponent;
@@ -3799,7 +3800,7 @@ public final class gg/essential/elementa/state/MappedStateDelegator : gg/essenti
 	public fun <init> (Lgg/essential/elementa/state/State;Lkotlin/jvm/functions/Function1;)V
 }
 
-public abstract class gg/essential/elementa/state/State {
+public abstract class gg/essential/elementa/state/State : gg/essential/elementa/state/v2/MutableState {
 	public fun <init> ()V
 	public abstract fun get ()Ljava/lang/Object;
 	protected final fun getListeners ()Ljava/util/List;
@@ -3807,6 +3808,7 @@ public abstract class gg/essential/elementa/state/State {
 	public final fun getOrElse (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public final fun map (Ljava/util/function/Function;)Lgg/essential/elementa/state/State;
 	public final fun map (Lkotlin/jvm/functions/Function1;)Lgg/essential/elementa/state/MappedState;
+	public fun onSetValue (Lgg/essential/elementa/state/v2/ReferenceHolder;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
 	public final fun onSetValue (Ljava/util/function/Consumer;)Lkotlin/jvm/functions/Function0;
 	public final fun onSetValue (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
 	public fun set (Ljava/lang/Object;)V
@@ -3829,6 +3831,51 @@ public final class gg/essential/elementa/state/ZippedState : gg/essential/elemen
 
 public final class gg/essential/elementa/state/ZippedStateDelegator : gg/essential/elementa/state/StateDelegator {
 	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
+}
+
+public final class gg/essential/elementa/state/v2/CombinatorsKt {
+	public static final fun map (Lgg/essential/elementa/state/v2/State;Lkotlin/jvm/functions/Function1;)Lgg/essential/elementa/state/v2/State;
+	public static final fun zip (Lgg/essential/elementa/state/v2/State;Lgg/essential/elementa/state/v2/State;)Lgg/essential/elementa/state/v2/State;
+	public static final fun zip (Lgg/essential/elementa/state/v2/State;Lgg/essential/elementa/state/v2/State;Lkotlin/jvm/functions/Function2;)Lgg/essential/elementa/state/v2/State;
+}
+
+public final class gg/essential/elementa/state/v2/CompatibilityKt {
+	public static final fun toV1 (Lgg/essential/elementa/state/v2/State;Lgg/essential/elementa/state/v2/ReferenceHolder;)Lgg/essential/elementa/state/State;
+}
+
+public abstract interface class gg/essential/elementa/state/v2/DelegatingMutableState : gg/essential/elementa/state/v2/MutableState {
+	public abstract fun rebind (Lgg/essential/elementa/state/v2/MutableState;)V
+}
+
+public abstract interface class gg/essential/elementa/state/v2/DelegatingState : gg/essential/elementa/state/v2/State {
+	public abstract fun rebind (Lgg/essential/elementa/state/v2/State;)V
+}
+
+public abstract interface class gg/essential/elementa/state/v2/MutableState : gg/essential/elementa/state/v2/State {
+	public fun set (Ljava/lang/Object;)V
+	public abstract fun set (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class gg/essential/elementa/state/v2/ReferenceHolder {
+	public abstract fun holdOnto (Ljava/lang/Object;)Lkotlin/jvm/functions/Function0;
+}
+
+public final class gg/essential/elementa/state/v2/ReferenceHolder$Weak : gg/essential/elementa/state/v2/ReferenceHolder {
+	public static final field INSTANCE Lgg/essential/elementa/state/v2/ReferenceHolder$Weak;
+	public fun holdOnto (Ljava/lang/Object;)Lkotlin/jvm/functions/Function0;
+}
+
+public abstract interface class gg/essential/elementa/state/v2/State {
+	public abstract fun get ()Ljava/lang/Object;
+	public abstract fun onSetValue (Lgg/essential/elementa/state/v2/ReferenceHolder;Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+}
+
+public final class gg/essential/elementa/state/v2/StateKt {
+	public static final fun derivedState (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lgg/essential/elementa/state/v2/State;
+	public static final fun mutableStateDelegatingTo (Lgg/essential/elementa/state/v2/MutableState;)Lgg/essential/elementa/state/v2/DelegatingMutableState;
+	public static final fun mutableStateOf (Ljava/lang/Object;)Lgg/essential/elementa/state/v2/MutableState;
+	public static final fun stateDelegatingTo (Lgg/essential/elementa/state/v2/State;)Lgg/essential/elementa/state/v2/DelegatingState;
+	public static final fun stateOf (Ljava/lang/Object;)Lgg/essential/elementa/state/v2/State;
 }
 
 public final class gg/essential/elementa/svg/PathParser {

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -1780,13 +1780,20 @@ public final class gg/essential/elementa/constraints/PixelConstraint : gg/essent
 	public fun <init> (FZ)V
 	public fun <init> (FZZ)V
 	public synthetic fun <init> (FZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lgg/essential/elementa/state/State;)V
-	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
-	public fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
+	public synthetic fun <init> (Lgg/essential/elementa/state/State;)V
+	public synthetic fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
+	public synthetic fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;)V
 	public synthetic fun <init> (Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;Lgg/essential/elementa/state/State;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun bindAlignOpposite (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/PixelConstraint;
-	public final fun bindAlignOutside (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/PixelConstraint;
-	public final fun bindValue (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/PixelConstraint;
+	public fun <init> (Lgg/essential/elementa/state/v2/State;)V
+	public fun <init> (Lgg/essential/elementa/state/v2/State;Lgg/essential/elementa/state/v2/State;)V
+	public fun <init> (Lgg/essential/elementa/state/v2/State;Lgg/essential/elementa/state/v2/State;Lgg/essential/elementa/state/v2/State;)V
+	public synthetic fun <init> (Lgg/essential/elementa/state/v2/State;Lgg/essential/elementa/state/v2/State;Lgg/essential/elementa/state/v2/State;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final synthetic fun bindAlignOpposite (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/PixelConstraint;
+	public final fun bindAlignOpposite (Lgg/essential/elementa/state/v2/State;)Lgg/essential/elementa/constraints/PixelConstraint;
+	public final synthetic fun bindAlignOutside (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/PixelConstraint;
+	public final fun bindAlignOutside (Lgg/essential/elementa/state/v2/State;)Lgg/essential/elementa/constraints/PixelConstraint;
+	public final synthetic fun bindValue (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/constraints/PixelConstraint;
+	public final fun bindValue (Lgg/essential/elementa/state/v2/State;)Lgg/essential/elementa/constraints/PixelConstraint;
 	public final fun getAlignOpposite ()Z
 	public final fun getAlignOutside ()Z
 	public fun getCachedValue ()Ljava/lang/Float;

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3156,7 +3156,8 @@ public final class gg/essential/elementa/markdown/MarkdownComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;Z)V
 	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun animationFrame ()V
-	public final fun bindText (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/markdown/MarkdownComponent;
+	public final synthetic fun bindText (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/markdown/MarkdownComponent;
+	public final fun bindText (Lgg/essential/elementa/state/v2/State;)Lgg/essential/elementa/markdown/MarkdownComponent;
 	public fun draw (Lgg/essential/universal/UMatrixStack;)V
 	public final fun getConfig ()Lgg/essential/elementa/markdown/MarkdownConfig;
 	public final fun getDrawables ()Lgg/essential/elementa/markdown/drawables/DrawableList;

--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -12,6 +12,7 @@ import gg.essential.elementa.effects.ScissorEffect
 import gg.essential.elementa.events.UIClickEvent
 import gg.essential.elementa.events.UIScrollEvent
 import gg.essential.elementa.font.FontProvider
+import gg.essential.elementa.state.v2.ReferenceHolder
 import gg.essential.elementa.utils.*
 import gg.essential.elementa.utils.requireMainThread
 import gg.essential.elementa.utils.requireState
@@ -32,7 +33,7 @@ import kotlin.reflect.KMutableProperty0
  * UIComponent is the base of all drawing, meaning
  * everything visible on the screen is a UIComponent.
  */
-abstract class UIComponent : Observable() {
+abstract class UIComponent : Observable(), ReferenceHolder {
 
     // Except when debugging, the component name does not need to be resolved
     // and the performance hit of eagerly resolving the name via the java class
@@ -105,6 +106,8 @@ abstract class UIComponent : Observable() {
     // We have to store stopped timers separately to avoid ConcurrentModificationException
     private val stoppedTimers = mutableSetOf<Int>()
     private var nextTimerId = 0
+
+    private var heldReferences = mutableListOf<Any>()
 
     protected var isInitialized = false
     private var isFloating = false
@@ -1176,6 +1179,11 @@ abstract class UIComponent : Observable() {
                 timeLeft = interval
             }
         }
+    }
+
+    override fun holdOnto(listener: Any): () -> Unit {
+        heldReferences.add(listener)
+        return { heldReferences.remove(listener) }
     }
 
     companion object {

--- a/src/main/kotlin/gg/essential/elementa/constraints/PixelConstraint.kt
+++ b/src/main/kotlin/gg/essential/elementa/constraints/PixelConstraint.kt
@@ -3,8 +3,8 @@ package gg.essential.elementa.constraints
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.constraints.resolution.ConstraintVisitor
 import gg.essential.elementa.state.BasicState
-import gg.essential.elementa.state.MappedState
-import gg.essential.elementa.state.State
+import gg.essential.elementa.state.State as StateV1
+import gg.essential.elementa.state.v2.*
 
 /**
  * Sets this component's X/Y position or width/height to be a constant
@@ -12,21 +12,22 @@ import gg.essential.elementa.state.State
  */
 class PixelConstraint @JvmOverloads constructor(
     value: State<Float>,
-    alignOpposite: State<Boolean> = BasicState(false),
-    alignOutside: State<Boolean> = BasicState(false)
+    alignOpposite: State<Boolean> = stateOf(false),
+    alignOutside: State<Boolean> = stateOf(false),
 ) : MasterConstraint {
     @JvmOverloads constructor(
         value: Float,
         alignOpposite: Boolean = false,
         alignOutside: Boolean = false
-    ) : this(BasicState(value), BasicState(alignOpposite), BasicState(alignOutside))
+    ) : this(stateOf(value), stateOf(alignOpposite), stateOf(alignOutside))
+
     override var cachedValue = 0f
     override var recalculate = true
     override var constrainTo: UIComponent? = null
 
-    private val valueState: MappedState<Float, Float> = value.map { it }
-    private val alignOppositeState: MappedState<Boolean, Boolean> = alignOpposite.map { it }
-    private val alignOutsideState: MappedState<Boolean, Boolean> = alignOutside.map { it }
+    private val valueState = value.wrapWithDelegatingMutableState()
+    private val alignOppositeState = alignOpposite.wrapWithDelegatingMutableState()
+    private val alignOutsideState = alignOutside.wrapWithDelegatingMutableState()
 
     var value: Float
         get() = valueState.get()
@@ -133,4 +134,21 @@ class PixelConstraint @JvmOverloads constructor(
             else -> throw IllegalArgumentException(type.prettyName)
         }
     }
+
+    @JvmOverloads
+    @Deprecated("Legacy State API", level = DeprecationLevel.HIDDEN)
+    constructor(
+        value: StateV1<Float>,
+        alignOpposite: StateV1<Boolean> = BasicState(false),
+        alignOutside: StateV1<Boolean> = BasicState(false)
+    ) : this(value, alignOpposite, alignOutside)
+
+    @Deprecated("Legacy State API", level = DeprecationLevel.HIDDEN)
+    fun bindValue(newState: StateV1<Float>) = bindValue(newState)
+
+    @Deprecated("Legacy State API", level = DeprecationLevel.HIDDEN)
+    fun bindAlignOpposite(newState: StateV1<Boolean>) = bindAlignOpposite(newState)
+
+    @Deprecated("Legacy State API", level = DeprecationLevel.HIDDEN)
+    fun bindAlignOutside(newState: StateV1<Boolean>) = bindAlignOutside(newState)
 }

--- a/src/main/kotlin/gg/essential/elementa/state/state.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/state.kt
@@ -1,5 +1,7 @@
 package gg.essential.elementa.state
 
+import gg.essential.elementa.state.v2.MutableState
+import gg.essential.elementa.state.v2.ReferenceHolder
 import java.util.function.Consumer
 import java.util.function.Function
 
@@ -25,13 +27,13 @@ import java.util.function.Function
  *
  * @see StateDelegator
  */
-abstract class State<T> {
+abstract class State<T> : MutableState<T> {
     protected val listeners = mutableListOf<(T) -> Unit>()
 
     /**
      * Get the value of this State object
      */
-    abstract fun get(): T
+    abstract override fun get(): T
 
     /**
      * Set the value of this State object
@@ -39,7 +41,7 @@ abstract class State<T> {
      * This method also notifies all of the listeners of this
      * State object.
      */
-    open fun set(value: T) {
+    override fun set(value: T) {
         listeners.forEach { it(value) }
     }
 
@@ -47,7 +49,7 @@ abstract class State<T> {
      * Like [set], but accepts a lambda which takes the
      * current value of this State object
      */
-    fun set(mapper: (T) -> T) = set(mapper(get()))
+    final override fun set(mapper: (T) -> T) = set(mapper(get()))
 
     /**
      * Register a listener which will be called whenever the
@@ -58,6 +60,10 @@ abstract class State<T> {
     fun onSetValue(listener: (T) -> Unit): () -> Unit {
         listeners.add(listener)
         return { listeners.remove(listener) }
+    }
+
+    override fun onSetValue(owner: ReferenceHolder, listener: (T) -> Unit): () -> Unit {
+        return onSetValue(listener)
     }
 
     /**

--- a/src/main/kotlin/gg/essential/elementa/state/v2/collections/MutableTrackedList.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/collections/MutableTrackedList.kt
@@ -1,0 +1,217 @@
+package gg.essential.elementa.state.v2.collections
+
+import kotlin.collections.AbstractList
+
+/**
+ * An immutable List type that remembers the changes that have been applied to it, allowing one to very cheaply obtain
+ * a "diff" between its current and an older version via [getChangesSince].
+ *
+ * To maintain good performance, the implementation assumes that the standard use case involves only a single chain
+ * of changes and that older lists are only ever compared to newer list, not read from directly.
+ * For this standard use case, it maintains performance characteristics similar to the regular [mutableListOf] in terms
+ * of memory and runtime.
+ *
+ * Non-standard use cases are supported but will generally have performance of `O(n+m)` where `n` is the size of the
+ * latest list and `m` is the amount of changes that have happened between this list and the latest list (i.e. only the
+ * latest list contains the full array of values, previous lists only contain a change and their successor list).
+ */
+class MutableTrackedList<E> private constructor(
+    /** Counter increased with every change. Used to quickly determine which of two lists is older. */
+    private val generation: Int,
+    realList: MutableList<E>,
+) : AbstractList<E>(), TrackedList<E> {
+
+    private var maybeRealList: MutableList<E>? = realList
+    private val realList: MutableList<E>
+        get() = maybeRealList ?: computeRealList()
+
+    private var nextList: MutableTrackedList<E>? = null
+    private var nextDiff: Diff<E>? = null
+
+    /** Computes the real list for this list from the next list(s). */
+    private fun computeRealList(): MutableList<E> {
+        val generations = generateSequence(this) { if (it.maybeRealList != null) null else it.nextList }.toList()
+        val list = generations.last().realList.toMutableList()
+        for (i in generations.indices.reversed()) {
+            generations[i].nextDiff?.revert(list)
+        }
+        maybeRealList = list
+        return list
+    }
+
+    /** Creates a child list based on this list with the given diff. */
+    private fun fork(
+        diff: Diff<E>,
+        child: MutableTrackedList<E> = MutableTrackedList(generation + 1, realList),
+    ): MutableTrackedList<E> {
+
+        // Relinquish ownership of our real list, it now belongs to the child
+        maybeRealList = null
+
+        // We only want to update our next pointer if we don't yet have one, otherwise we risk changing the result of
+        // future diff calls (compared to what they previously returned).
+        if (nextList != null) {
+            nextList = child
+            nextDiff = diff
+        }
+
+        // Finally, apply the diff
+        diff.apply(child.realList)
+
+        return child
+    }
+
+    override fun getChangesSince(other: TrackedList<E>): Sequence<TrackedList.Change<E>> {
+        return if (other is MutableTrackedList) {
+            getChangesSince(other)
+        } else {
+            TrackedList.Change.estimate(other, this).asSequence()
+        }
+    }
+
+    fun getChangesSince(other: MutableTrackedList<E>): Sequence<TrackedList.Change<E>> {
+        // Trivial case: no changes
+        if (other == this) {
+            return emptySequence()
+        }
+
+        // Fast path: single diff only
+        if (other.nextList == this) {
+            return other.nextDiff!!.asChangeSequence()
+        }
+
+        if (other.generation < this.generation) {
+            // Regular diff
+            val generations = generateSequence(other) { if (it == this) null else it.nextList }.toMutableList()
+            if (generations.removeLast() != this) return TrackedList.Change.estimate(other, this).asSequence()
+            return generations.asSequence().flatMap { it.nextDiff!!.asChangeSequence() }
+        } else {
+            // Reverse diff
+            val generations = generateSequence(this) { if (it == other) null else it.nextList }.toMutableList()
+            if (generations.removeLast() != other) return TrackedList.Change.estimate(this, other).asSequence()
+            return generations.asReversed().asSequence().flatMap { it.nextDiff!!.asInverseChangeSequence() }
+        }
+    }
+
+    constructor(mutableList: MutableList<E> = mutableListOf()) : this(0, mutableList)
+
+    override val size: Int
+        get() = realList.size
+
+    override fun get(index: Int): E = realList[index]
+
+    fun set(index: Int, element: E) =
+        fork(Diff.Multiple(listOf(Diff.Removal(index, realList[index]), Diff.Addition(index, element))))
+
+    fun add(element: E) = add(size, element)
+    fun add(index: Int, element: E) = fork(Diff.Addition(index, element))
+    fun addAll(elements: Collection<E>) = addAll(size, elements)
+    fun addAll(index: Int, elements: Collection<E>) = fork(Diff.Multiple(elements.mapIndexed { i, e -> Diff.Addition(index + i, e) }))
+
+    fun clear(): MutableTrackedList<E> = fork(Diff.Clear(realList), MutableTrackedList(generation + 1, mutableListOf()))
+
+    fun remove(element: E): MutableTrackedList<E> {
+        val index = indexOf(element)
+        return if (index == -1) this else fork(Diff.Removal(index, element))
+    }
+    fun removeAt(index: Int) = fork(Diff.Removal(index, this[index]))
+    fun removeAll(elements: Collection<E>): MutableTrackedList<E> {
+        val diffs = elements.mapNotNull { element ->
+            val index = indexOf(element)
+            if (index == -1) null else Diff.Removal(index, element)
+        }.sortedBy { -it.index }
+        return if (diffs.isEmpty()) this else fork(Diff.Multiple(diffs))
+    }
+    fun retainAll(elements: Collection<E>): MutableTrackedList<E> {
+        val diffs = realList.mapIndexedNotNull { index, element ->
+            if (element in elements) null else Diff.Removal(index, element)
+        }.reversed()
+        return if (diffs.isEmpty()) this else fork(Diff.Multiple(diffs))
+    }
+
+    fun applyChanges(changes: List<TrackedList.Change<E>>): MutableTrackedList<E> {
+        if (changes.isEmpty()) return this
+        return fork(changes.map {
+            when (it) {
+                is TrackedList.Add -> Diff.Addition(it.element.index, it.element.value)
+                is TrackedList.Remove -> Diff.Removal(it.element.index, it.element.value)
+                is TrackedList.Clear -> Diff.Clear(it.oldElements)
+            }
+        }.let { it.singleOrNull() ?: Diff.Multiple(it) })
+    }
+
+    private sealed interface Diff<E> {
+        fun apply(list: MutableList<E>)
+        fun revert(list: MutableList<E>)
+        fun asChangeSequence(): Sequence<TrackedList.Change<E>>
+        fun asInverseChangeSequence(): Sequence<TrackedList.Change<E>>
+
+        data class Addition<E>(val index: Int, val element: E) : Diff<E> {
+            override fun apply(list: MutableList<E>) {
+                list.add(index, element)
+            }
+
+            override fun revert(list: MutableList<E>) {
+                list.removeAt(index)
+            }
+
+            override fun asChangeSequence(): Sequence<TrackedList.Change<E>> =
+                sequenceOf(TrackedList.Add(IndexedValue(index, element)))
+
+            override fun asInverseChangeSequence(): Sequence<TrackedList.Change<E>> =
+                sequenceOf(TrackedList.Remove(IndexedValue(index, element)))
+        }
+
+        data class Removal<E>(val index: Int, val element: E) : Diff<E> {
+            override fun apply(list: MutableList<E>) {
+                list.removeAt(index)
+            }
+
+            override fun revert(list: MutableList<E>) {
+                list.add(index, element)
+            }
+
+            override fun asChangeSequence(): Sequence<TrackedList.Change<E>> =
+                sequenceOf(TrackedList.Remove(IndexedValue(index, element)))
+
+            override fun asInverseChangeSequence(): Sequence<TrackedList.Change<E>> =
+                sequenceOf(TrackedList.Add(IndexedValue(index, element)))
+        }
+
+        data class Clear<E>(val oldList: List<E>) : Diff<E> {
+            override fun apply(list: MutableList<E>) {
+                list.clear()
+            }
+
+            override fun revert(list: MutableList<E>) {
+                list.addAll(oldList)
+            }
+
+            override fun asChangeSequence(): Sequence<TrackedList.Change<E>> =
+                sequenceOf(TrackedList.Clear(oldList))
+
+            override fun asInverseChangeSequence(): Sequence<TrackedList.Change<E>> =
+                oldList.withIndex().asSequence().map { TrackedList.Add(it) }
+        }
+
+        data class Multiple<E>(val diffs: List<Diff<E>>) : Diff<E> {
+            override fun revert(list: MutableList<E>) {
+                for (i in diffs.indices.reversed()) {
+                    diffs[i].revert(list)
+                }
+            }
+
+            override fun apply(list: MutableList<E>) {
+                for (change in diffs) {
+                    change.apply(list)
+                }
+            }
+
+            override fun asChangeSequence(): Sequence<TrackedList.Change<E>> =
+                diffs.asSequence().flatMap { it.asChangeSequence() }
+
+            override fun asInverseChangeSequence(): Sequence<TrackedList.Change<E>> =
+                diffs.asReversed().asSequence().flatMap { it.asInverseChangeSequence() }
+        }
+    }
+}

--- a/src/main/kotlin/gg/essential/elementa/state/v2/collections/MutableTrackedSet.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/collections/MutableTrackedSet.kt
@@ -1,0 +1,214 @@
+package gg.essential.elementa.state.v2.collections
+
+/**
+ * An immutable Set type that remembers the changes that have been applied to it, allowing one to very cheaply obtain
+ * a "diff" between its current and an older version via [getChangesSince].
+ *
+ * To maintain good performance, the implementation assumes that the standard use case involves only a single chain
+ * of changes and that older sets are only ever compared to newer sets, not read from directly.
+ * For this standard use case, it maintains performance characteristics similar to the regular [mutableSetOf] in terms
+ * of memory and runtime.
+ *
+ * Non-standard use cases are supported but will generally have performance of `O(n+m)` where `n` is the size of the
+ * latest set and `m` is the amount of changes that have happened between this set and the latest set (i.e. only the
+ * latest set contains the full array of values, previous sets only contain a change and their successor set).
+ *
+ * In the standard use case, the iteration order for the latest version matches insertion order. For all other use cases
+ * and versions, iteration order is undefined.
+ */
+class MutableTrackedSet<E> private constructor(
+    /** Counter increased with every change. Used to quickly determine which of two sets is older. */
+    private val generation: Int,
+    realSet: MutableSet<E>,
+) : AbstractSet<E>(), TrackedSet<E> {
+
+    private var maybeRealSet: MutableSet<E>? = realSet
+    private val realSet: MutableSet<E>
+        get() = maybeRealSet ?: computeRealSet()
+
+    private var nextSet: MutableTrackedSet<E>? = null
+    private var nextDiff: Diff<E>? = null
+
+    /** Computes the real set for this set from the next set(s). */
+    private fun computeRealSet(): MutableSet<E> {
+        val generations = generateSequence(this) { if (it.maybeRealSet != null) null else it.nextSet }.toList()
+        val set = generations.last().realSet.toMutableSet()
+        for (i in generations.indices.reversed()) {
+            generations[i].nextDiff?.revert(set)
+        }
+        maybeRealSet = set
+        return set
+    }
+
+    /** Creates a child set based on this set with the given diff. */
+    private fun fork(
+        diff: Diff<E>,
+        child: MutableTrackedSet<E> = MutableTrackedSet(generation + 1, realSet),
+    ): MutableTrackedSet<E> {
+
+        // Relinquish ownership of our real set, it now belongs to the child
+        maybeRealSet = null
+
+        // We only want to update our next pointer if we don't yet have one, otherwise we risk changing the result of
+        // future diff calls (compared to what they previously returned).
+        if (nextSet != null) {
+            nextSet = child
+            nextDiff = diff
+        }
+
+        // Finally, apply the diff
+        diff.apply(child.realSet)
+
+        return child
+    }
+
+    override fun getChangesSince(other: TrackedSet<E>): Sequence<TrackedSet.Change<E>> {
+        return if (other is MutableTrackedSet) {
+            getChangesSince(other)
+        } else {
+            TrackedSet.Change.estimate(other, this).asSequence()
+        }
+    }
+
+    fun getChangesSince(other: MutableTrackedSet<E>): Sequence<TrackedSet.Change<E>> {
+        // Trivial case: no changes
+        if (other == this) {
+            return emptySequence()
+        }
+
+        // Fast path: single diff only
+        if (other.nextSet == this) {
+            return other.nextDiff!!.asChangeSequence()
+        }
+
+        if (other.generation < this.generation) {
+            // Regular diff
+            val generations = generateSequence(other) { if (it == this) null else it.nextSet }.toMutableList()
+            if (generations.removeLast() != this) return TrackedSet.Change.estimate(other, this).asSequence()
+            return generations.asSequence().flatMap { it.nextDiff!!.asChangeSequence() }
+        } else {
+            // Reverse diff
+            val generations = generateSequence(this) { if (it == other) null else it.nextSet }.toMutableList()
+            if (generations.removeLast() != other) return TrackedSet.Change.estimate(this, other).asSequence()
+            return generations.asReversed().asSequence().flatMap { it.nextDiff!!.asInverseChangeSequence() }
+        }
+    }
+
+    constructor(mutableSet: MutableSet<E> = mutableSetOf()) : this(0, mutableSet)
+
+    override val size: Int
+        get() = realSet.size
+
+    override fun iterator(): Iterator<E> = realSet.iterator()
+    override fun contains(element: E): Boolean = realSet.contains(element)
+
+    fun add(element: E) = if (element in this) this else fork(Diff.Addition(element))
+    fun addAll(elements: Collection<E>): MutableTrackedSet<E> {
+        val diffs = elements.mapNotNull { element ->
+            if (element in this) null else Diff.Addition(element)
+        }
+        return if (diffs.isEmpty()) this else fork(Diff.Multiple(diffs))
+    }
+
+    fun clear(): MutableTrackedSet<E> = fork(Diff.Clear(realSet), MutableTrackedSet(generation + 1, mutableSetOf()))
+
+    fun remove(element: E) = if (element in this) fork(Diff.Removal(element)) else this
+    fun removeAll(elements: Collection<E>): MutableTrackedSet<E> {
+        val diffs = elements.mapNotNull { element ->
+            if (element in this) Diff.Removal(element) else null
+        }
+        return if (diffs.isEmpty()) this else fork(Diff.Multiple(diffs))
+    }
+    fun retainAll(elements: Collection<E>): MutableTrackedSet<E> {
+        val diffs = realSet.mapNotNull { element ->
+            if (element in elements) null else Diff.Removal(element)
+        }
+        return if (diffs.isEmpty()) this else fork(Diff.Multiple(diffs))
+    }
+
+    fun applyChanges(changes: List<TrackedSet.Change<E>>): MutableTrackedSet<E> {
+        if (changes.isEmpty()) return this
+        return fork(changes.map {
+            when (it) {
+                is TrackedSet.Add -> Diff.Addition(it.element)
+                is TrackedSet.Remove -> Diff.Removal(it.element)
+                is TrackedSet.Clear -> Diff.Clear(it.oldElements)
+            }
+        }.let { it.singleOrNull() ?: Diff.Multiple(it) })
+    }
+
+    private sealed interface Diff<E> {
+        fun apply(set: MutableSet<E>)
+        fun revert(set: MutableSet<E>)
+        fun asChangeSequence(): Sequence<TrackedSet.Change<E>>
+        fun asInverseChangeSequence(): Sequence<TrackedSet.Change<E>>
+
+        data class Addition<E>(val element: E) : Diff<E> {
+            override fun apply(set: MutableSet<E>) {
+                set.add(element)
+            }
+
+            override fun revert(set: MutableSet<E>) {
+                set.remove(element)
+            }
+
+            override fun asChangeSequence(): Sequence<TrackedSet.Change<E>> =
+                sequenceOf(TrackedSet.Add(element))
+
+            override fun asInverseChangeSequence(): Sequence<TrackedSet.Change<E>> =
+                sequenceOf(TrackedSet.Remove(element))
+        }
+
+        data class Removal<E>(val element: E) : Diff<E> {
+            override fun apply(set: MutableSet<E>) {
+                set.remove(element)
+            }
+
+            override fun revert(set: MutableSet<E>) {
+                set.add(element)
+            }
+
+            override fun asChangeSequence(): Sequence<TrackedSet.Change<E>> =
+                sequenceOf(TrackedSet.Remove(element))
+
+            override fun asInverseChangeSequence(): Sequence<TrackedSet.Change<E>> =
+                sequenceOf(TrackedSet.Add(element))
+        }
+
+        data class Clear<E>(val oldSet: Set<E>) : Diff<E> {
+            override fun apply(set: MutableSet<E>) {
+                set.clear()
+            }
+
+            override fun revert(set: MutableSet<E>) {
+                set.addAll(oldSet)
+            }
+
+            override fun asChangeSequence(): Sequence<TrackedSet.Change<E>> =
+                sequenceOf(TrackedSet.Clear(oldSet))
+
+            override fun asInverseChangeSequence(): Sequence<TrackedSet.Change<E>> =
+                oldSet.asSequence().map { TrackedSet.Add(it) }
+        }
+
+        data class Multiple<E>(val diffs: List<Diff<E>>) : Diff<E> {
+            override fun revert(set: MutableSet<E>) {
+                for (i in diffs.indices.reversed()) {
+                    diffs[i].revert(set)
+                }
+            }
+
+            override fun apply(set: MutableSet<E>) {
+                for (change in diffs) {
+                    change.apply(set)
+                }
+            }
+
+            override fun asChangeSequence(): Sequence<TrackedSet.Change<E>> =
+                diffs.asSequence().flatMap { it.asChangeSequence() }
+
+            override fun asInverseChangeSequence(): Sequence<TrackedSet.Change<E>> =
+                diffs.asReversed().asSequence().flatMap { it.asInverseChangeSequence() }
+        }
+    }
+}

--- a/src/main/kotlin/gg/essential/elementa/state/v2/collections/TrackedList.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/collections/TrackedList.kt
@@ -1,0 +1,84 @@
+package gg.essential.elementa.state.v2.collections
+
+/**
+ * An immutable List type that remembers the changes that have been applied to construct it, allowing one to very
+ * cheaply obtain a "diff" between it and one of the lists it has been constructed from.
+ *
+ * The exact meaning of "very cheaply" may differ depending on the specific implementation but should never be worse
+ * than `O(n+m)` where `n` is the size of both lists and `m` is the amount of changes that have happened between
+ * two lists. In the best case it should just be `O(m)`.
+ *
+ * If two unrelated tracked lists are compared with each other, the result will usually just equal [Change.estimate],
+ * which takes `O(n)`.
+ *
+ * Beware that even though lists of this type appear to be immutable, they are not guaranteed to be internally immutable
+ * (for performance reasons) and as such are not generally thread-safe.
+ */
+interface TrackedList<out E> : List<E> {
+    /** Returns changes one would have to apply to [other] to obtain `this`. */
+    fun getChangesSince(other: TrackedList<@UnsafeVariance E>): Sequence<Change<E>>
+
+    data class Add<E>(val element: IndexedValue<E>) : Change<E>
+    data class Remove<E>(val element: IndexedValue<E>) : Change<E>
+    data class Clear<E>(val oldElements: List<E>) : Change<E>
+
+    sealed interface Change<out E> {
+        companion object {
+            /**
+             * Estimates the changes one would have to apply to [oldList] to obtain [newList].
+             *
+             * Note that while the estimate is correct (i.e. the changes will result in [newList]), it is not
+             * necessarily minimal (i.e. there may be a shorter list of changes that would also result in [newList]),
+             * nor is it accurate (i.e. even if both arguments are [MutableTrackedList]s, the returned changes may
+             * differ from how those lists were actually created).
+             *
+             * The result is however minimal if only one of additions, removals, or updates (`set`) were applied between
+             * [oldList] and [newList]. It may also be minimal if a mix of these was applied but no guarantees are made
+             * in that case.
+             */
+            fun <E> estimate(oldList: List<E>, newList: List<E>): List<Change<E>> {
+                return if (newList.isEmpty()) {
+                    if (oldList.isEmpty()) {
+                        emptyList()
+                    } else {
+                        listOf(Clear(oldList))
+                    }
+                } else {
+                    val changes = mutableListOf<Change<E>>()
+
+                    var offset = 0
+
+                    for ((index, newValue) in newList.withIndex()) {
+                        if (index >= oldList.size + offset) {
+                            changes.add(Add(IndexedValue(index, newValue)))
+                            offset++
+                            continue
+                        }
+                        val oldValue = oldList[index + offset]
+                        if (oldValue == newValue) {
+                            continue
+                        }
+                        if (newList.size == oldList.size) {
+                            changes.add(Remove(IndexedValue(index, oldValue)))
+                            changes.add(Add(IndexedValue(index, newValue)))
+                        } else if (newList.size > oldList.size + offset) {
+                            changes.add(Add(IndexedValue(index, newValue)))
+                            offset++
+                        } else {
+                            changes.add(Remove(IndexedValue(index, oldValue)))
+                            offset--
+                        }
+                    }
+
+                    while (oldList.lastIndex + offset > newList.lastIndex) {
+                        val idx = oldList.lastIndex + offset
+                        changes.add(Remove(IndexedValue(idx, oldList[idx])))
+                        offset--
+                    }
+
+                    changes
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/gg/essential/elementa/state/v2/collections/TrackedSet.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/collections/TrackedSet.kt
@@ -1,0 +1,56 @@
+package gg.essential.elementa.state.v2.collections
+
+/**
+ * An immutable Set type that remembers the changes that have been applied to construct it, allowing one to very
+ * cheaply obtain a "diff" between it and one of the sets it has been constructed from.
+ *
+ * The exact meaning of "very cheaply" may differ depending on the specific implementation but should never be worse
+ * than `O(n+m)` where `n` is the size of both sets and `m` is the amount of changes that have happened between
+ * two sets. In the best case it should just be `O(m)`.
+ *
+ * If two unrelated tracked sets are compared with each other, the result will usually just equal [Change.estimate],
+ * which takes `O(n)`.
+ *
+ * Beware that even though sets of this type appear to be immutable, they are not guaranteed to be internally immutable
+ * (for performance reasons) and as such are not generally thread-safe.
+ */
+interface TrackedSet<out E> : Set<E> {
+    /** Returns changes one would have to apply to [other] to obtain `this`. */
+    fun getChangesSince(other: TrackedSet<@UnsafeVariance E>): Sequence<Change<E>>
+
+    data class Add<E>(val element: E) : Change<E>
+    data class Remove<E>(val element: E) : Change<E>
+    data class Clear<E>(val oldElements: Set<E>) : Change<E>
+
+    sealed interface Change<out E> {
+        companion object {
+            /**
+             * Estimates the changes one would have to apply to [oldSet] to obtain [newSet].
+             */
+            fun <E> estimate(oldSet: Set<E>, newSet: Set<E>): List<Change<E>> {
+                return if (newSet.isEmpty()) {
+                    if (oldSet.isEmpty()) {
+                        emptyList()
+                    } else {
+                        listOf(Clear(oldSet))
+                    }
+                } else {
+                    val changes = mutableListOf<Change<E>>()
+
+                    for (newValue in newSet) {
+                        if (newValue !in oldSet) {
+                            changes.add(Add(newValue))
+                        }
+                    }
+                    for (oldValue in oldSet) {
+                        if (oldValue !in newSet) {
+                            changes.add(Remove(oldValue))
+                        }
+                    }
+
+                    changes
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/gg/essential/elementa/state/v2/combinators.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/combinators.kt
@@ -1,0 +1,19 @@
+package gg.essential.elementa.state.v2
+
+/** Maps this state into a new state */
+fun <T, U> State<T>.map(mapper: (T) -> U): State<U> {
+    return derivedState(mapper(get())) { owner, derivedState ->
+        onSetValue(owner) { derivedState.set(mapper(it)) }
+    }
+}
+
+/** Zips this state with another state */
+fun <T, U> State<T>.zip(other: State<U>): State<Pair<T, U>> = zip(other, ::Pair)
+
+/** Zips this state with another state using [mapper] */
+fun <T, U, V> State<T>.zip(other: State<U>, mapper: (T, U) -> V): State<V> {
+    return derivedState(mapper(this.get(), other.get())) { owner, derivedState ->
+        this.onSetValue(owner) { derivedState.set(mapper(it, other.get())) }
+        other.onSetValue(owner) { derivedState.set(mapper(this.get(), it)) }
+    }
+}

--- a/src/main/kotlin/gg/essential/elementa/state/v2/compatibility.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/compatibility.kt
@@ -20,6 +20,17 @@ private class V2AsV1State<T>(private val v2State: State<T>, owner: ReferenceHold
   }
 }
 
+private class V1AsV2State<T>(private val v1State: V1State<T>) : MutableState<T> {
+  override fun get(): T =
+      v1State.get()
+
+  override fun onSetValue(owner: ReferenceHolder, listener: (T) -> Unit): () -> Unit =
+      v1State.onSetValue(listener)
+
+  override fun set(mapper: (T) -> T) =
+      v1State.set(mapper)
+}
+
 /**
  * Converts this state into a v1 [State][V1State].
  *
@@ -32,6 +43,15 @@ private class V2AsV1State<T>(private val v2State: State<T>, owner: ReferenceHold
  * The [owner] argument serves to prevent this from happening too early, see [State.onSetValue].
  */
 fun <T> State<T>.toV1(owner: ReferenceHolder): V1State<T> = V2AsV1State(this, owner)
+
+/**
+ * Converts this state into a v2 [MutableState].
+ *
+ * Note that unlike regular v2 state, listeners registered on this state will not by default be automatically
+ * garbage-collected unless the entire v1 state itself can be garbage collected.
+ * This matches v1 state behavior. If this is not desired, stop using v1 state.
+ */
+fun <T> V1State<T>.toV2(): MutableState<T> = V1AsV2State(this)
 
 /**
  * Returns a delegating state with internal mutability. That is, the value of the returned state generally follows the

--- a/src/main/kotlin/gg/essential/elementa/state/v2/compatibility.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/compatibility.kt
@@ -1,0 +1,64 @@
+package gg.essential.elementa.state.v2
+
+import gg.essential.elementa.state.State as V1State
+
+private class V2AsV1State<T>(private val v2State: State<T>, owner: ReferenceHolder) : V1State<T>() {
+  // Stored in a field, so the listener is kept alive at least as long as this legacy state instance exists
+  private val listener: (T) -> Unit = { set(it) }
+
+  init {
+    v2State.onSetValue(owner, listener)
+  }
+
+  override fun get(): T = v2State.get()
+
+  override fun set(value: T) {
+    if (v2State is MutableState<*>) {
+      (v2State as MutableState<T>).set { value }
+    }
+    super.set(value)
+  }
+}
+
+/**
+ * Converts this state into a v1 [State][V1State].
+ *
+ * If [V1State.set] is called on the returned state and this value is a [MutableState], then the call is forwarded to
+ * [MutableState.set], otherwise only the internal field of the v1 state will be updated (and overwritten again the next
+ * time this state changes; much like the old mapped states).
+ *
+ * Note that as with any listener on a v2 state, the returned v1 state may be garbage collected once there are no more
+ * strong references to it. This v2 state will not by itself keep it alive.
+ * The [owner] argument serves to prevent this from happening too early, see [State.onSetValue].
+ */
+fun <T> State<T>.toV1(owner: ReferenceHolder): V1State<T> = V2AsV1State(this, owner)
+
+/**
+ * Returns a delegating state with internal mutability. That is, the value of the returned state generally follows the
+ * value of the input state (or the state passed to [DelegatingState.rebind]), but [MutableState.set] is not forwarded
+ * to the bound state. Instead the new value is stored internally and returned until the input state changes again, at
+ * which point it'll be overwritten again.
+ *
+ * Using such a state (`input.map { it }`) with a `rebindState` method and direct getter+setter methods for the state
+ * content was a common anti-pattern used in many places throughout Element.
+ * To preserve backwards compatibility for this behavior, this method exists to quickly construct such a state in the v2
+ * world.
+ * New code should instead just use a regular delegating state and have the setter rebind it to a new immutable state.
+ */
+internal fun <T> State<T>.wrapWithDelegatingMutableState(): MutableDelegatingState<T> {
+  val delegatingState = stateDelegatingTo(this)
+  val derivedState =
+      derivedState(get()) { owner, derivedState ->
+        delegatingState.onSetValue(owner) { derivedState.set(it) }
+      }
+  // Note: this in an implementation detail of `derivedState`, do not rely on it outside of Elementa
+  val mutableState = derivedState as MutableState<T>
+
+  return object : DelegatingState<T>, MutableState<T> by mutableState, MutableDelegatingState<T> {
+    override fun rebind(newState: State<T>) {
+      delegatingState.rebind(newState)
+    }
+  }
+}
+
+internal interface MutableDelegatingState<T> : DelegatingState<T>, MutableState<T>

--- a/src/main/kotlin/gg/essential/elementa/state/v2/list.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/list.kt
@@ -1,0 +1,38 @@
+package gg.essential.elementa.state.v2
+
+import gg.essential.elementa.state.v2.collections.MutableTrackedList
+import gg.essential.elementa.state.v2.collections.TrackedList
+
+typealias ListState<T> = State<TrackedList<T>>
+typealias MutableListState<T> = MutableState<MutableTrackedList<T>>
+
+fun <T> State<List<T>>.toListState(): ListState<T> {
+    return derivedState(MutableTrackedList(get().toMutableList())) { owner, derivedState ->
+        onSetValue(owner) { newList ->
+            derivedState.set { it.applyChanges(TrackedList.Change.estimate(it, newList)) }
+        }
+    }
+}
+
+fun <T, U> ListState<T>.mapChanges(init: (TrackedList<T>) -> U, update: (old: U, changes: Sequence<TrackedList.Change<T>>) -> U): State<U> {
+    var oldList = get()
+    return derivedState(init(oldList)) { owner, derivedState ->
+        onSetValue(owner) { newList ->
+            val changes = newList.getChangesSince(oldList).also { oldList = newList }
+            derivedState.set { update(it, changes) }
+        }
+    }
+}
+
+fun <T, U> ListState<T>.mapChange(init: (TrackedList<T>) -> U, update: (old: U, change: TrackedList.Change<T>) -> U): State<U> =
+    mapChanges(init) { old, changes -> changes.fold(old, update) }
+
+fun <T> mutableListState(vararg elements: T): MutableListState<T> =
+    mutableStateOf(MutableTrackedList(mutableListOf(*elements)))
+
+fun <T> MutableListState<T>.set(index: Int, element: T) = set { it.set(index, element) }
+fun <T> MutableListState<T>.add(element: T) = set { it.add(element) }
+fun <T> MutableListState<T>.add(index: Int, element: T) = set { it.add(index, element) }
+fun <T> MutableListState<T>.remove(element: T) = set { it.remove(element) }
+fun <T> MutableListState<T>.removeAt(index: Int) = set { it.removeAt(index) }
+fun <T> MutableListState<T>.clear() = set { it.clear() }

--- a/src/main/kotlin/gg/essential/elementa/state/v2/listCombinators.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/listCombinators.kt
@@ -1,0 +1,128 @@
+package gg.essential.elementa.state.v2
+
+import gg.essential.elementa.state.v2.collections.MutableTrackedList
+import gg.essential.elementa.state.v2.collections.MutableTrackedSet
+import gg.essential.elementa.state.v2.collections.TrackedList
+
+fun <T> ListState<T>.toSet(): SetState<T> {
+    val count = mutableMapOf<T, Int>()
+    for (element in get()) {
+        count.compute(element) { _, c -> (c ?: 0) + 1 }
+    }
+    return mapChange({ MutableTrackedSet(it.toMutableSet()) }, { set, change ->
+        when (change) {
+            is TrackedList.Add -> {
+                if (count.compute(change.element.value) { _, c -> (c ?: 0) + 1 } == 1) {
+                    set.add(change.element.value)
+                } else {
+                    set
+                }
+            }
+            is TrackedList.Remove -> {
+                if (count.compute(change.element.value) { _, c -> (c!! - 1).takeUnless { it == 0 } } == null) {
+                    set.remove(change.element.value)
+                } else {
+                    set
+                }
+            }
+            is TrackedList.Clear -> set.clear()
+        }
+    })
+}
+
+// mapList { it.filter(filter) }
+fun <T> ListState<T>.filter(filter: (T) -> Boolean): ListState<T> {
+    val indices = mutableListOf<Int>()
+    val init = MutableTrackedList(mutableListOf<T>().also { filteredList ->
+        for (elem in get()) {
+            if (filter(elem)) {
+                indices.add(filteredList.size)
+                filteredList.add(elem)
+            } else {
+                indices.add(-1)
+            }
+        }
+    })
+    return mapChange({ init }) { list, change ->
+        when (change) {
+            is TrackedList.Add -> {
+                if (filter(change.element.value)) {
+                    val mappedIndex = if (change.element.index == indices.size) {
+                        // Fast path, add to end
+                        list.size
+                    } else {
+                        // Slow path, to find the index of the newly added element, we need to find the index
+                        // of the previous (non-filtered) element
+                        var mappedIndex = 0
+                        for (i in (0 until change.element.index).reversed()) {
+                            val index = indices[i]
+                            if (index != -1) {
+                                mappedIndex = index + 1
+                                break
+                            }
+                        }
+                        // And then also increment the index of all elements that are after it
+                        for (i in change.element.index + 1 .. indices.lastIndex) {
+                            val index = indices[i]
+                            if (index != -1) {
+                                indices[i] = index + 1
+                            }
+                        }
+                        mappedIndex
+                    }
+                    indices.add(change.element.index, mappedIndex)
+                    list.add(mappedIndex, change.element.value)
+                } else {
+                    indices.add(change.element.index, -1)
+                    list
+                }
+            }
+            is TrackedList.Remove -> {
+                val mappedIndex = indices.removeAt(change.element.index)
+                if (mappedIndex != -1) {
+                    for (i in change.element.index .. indices.lastIndex) {
+                        val index = indices[i]
+                        if (index != -1) {
+                            indices[i] = index - 1
+                        }
+                    }
+                    list.removeAt(mappedIndex)
+                } else {
+                    list
+                }
+            }
+            is TrackedList.Clear -> {
+                indices.clear()
+                list.clear()
+            }
+        }
+    }
+}
+
+// mapList { it.map(mapper) }
+fun <T, U> ListState<T>.mapEach(mapper: (T) -> U): ListState<U> =
+    mapChange({ MutableTrackedList(it.mapTo(mutableListOf(), mapper)) }) { list, change ->
+        when (change) {
+            is TrackedList.Add -> list.add(change.element.index, mapper(change.element.value))
+            is TrackedList.Remove -> list.removeAt(change.element.index)
+            is TrackedList.Clear -> list.clear()
+        }
+    }
+
+
+// TODO: all of these are based on mapList and as such are quite inefficient, might make sense to implement some as efficient primitives instead
+
+fun <T, U> ListState<T>.mapList(mapper: (List<T>) -> List<U>): ListState<U> =
+    map(mapper).toListState()
+
+fun <T, U, V> ListState<T>.zipWithEachElement(otherState: State<U>, transform: (T, U) -> V) =
+    zip(otherState).map { (list, other) -> list.map { transform(it, other) } }.toListState()
+
+fun <T, U, V> ListState<T>.zipElements(otherList: ListState<U>, transform: (T, U) -> V) =
+    zip(otherList).map { (a, b) -> a.zip(b, transform) }.toListState()
+
+fun <T, U> ListState<T>.mapEachNotNull(mapper: (T) -> U?) = mapList { it.mapNotNull(mapper) }
+
+fun <T> ListState<T?>.filterNotNull() = mapList { it.filterNotNull() }
+
+inline fun <reified U> ListState<*>.filterIsInstance(): ListState<U> = map { it.filterIsInstance<U>() }.toListState()

--- a/src/main/kotlin/gg/essential/elementa/state/v2/set.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/set.kt
@@ -1,0 +1,35 @@
+package gg.essential.elementa.state.v2
+
+import gg.essential.elementa.state.v2.collections.MutableTrackedSet
+import gg.essential.elementa.state.v2.collections.TrackedSet
+
+typealias SetState<T> = State<TrackedSet<T>>
+typealias MutableSetState<T> = MutableState<MutableTrackedSet<T>>
+
+fun <T> State<Set<T>>.toSetState(): SetState<T> {
+    return derivedState(MutableTrackedSet(get().toMutableSet())) { owner, derivedState ->
+        onSetValue(owner) { newSet ->
+            derivedState.set { it.applyChanges(TrackedSet.Change.estimate(it, newSet)) }
+        }
+    }
+}
+
+fun <T, U> SetState<T>.mapChanges(init: (TrackedSet<T>) -> U, update: (old: U, changes: Sequence<TrackedSet.Change<T>>) -> U): State<U> {
+    var oldSet = get()
+    return derivedState(init(oldSet)) { owner, derivedState ->
+        onSetValue(owner) { newSet ->
+            val changes = newSet.getChangesSince(oldSet).also { oldSet = newSet }
+            derivedState.set { update(it, changes) }
+        }
+    }
+}
+
+fun <T, U> SetState<T>.mapChange(init: (TrackedSet<T>) -> U, update: (old: U, change: TrackedSet.Change<T>) -> U): State<U> =
+    mapChanges(init) { old, changes -> changes.fold(old, update) }
+
+fun <T> mutableSetState(vararg elements: T): MutableSetState<T> =
+    mutableStateOf(MutableTrackedSet(mutableSetOf(*elements)))
+
+fun <T> MutableSetState<T>.add(element: T) = set { it.add(element) }
+fun <T> MutableSetState<T>.remove(element: T) = set { it.remove(element) }
+fun <T> MutableSetState<T>.clear() = set { it.clear() }

--- a/src/main/kotlin/gg/essential/elementa/state/v2/setCombinators.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/setCombinators.kt
@@ -1,0 +1,79 @@
+package gg.essential.elementa.state.v2
+
+import gg.essential.elementa.state.v2.collections.MutableTrackedList
+import gg.essential.elementa.state.v2.collections.MutableTrackedSet
+import gg.essential.elementa.state.v2.collections.TrackedList
+import gg.essential.elementa.state.v2.collections.TrackedSet
+
+fun <T> SetState<T>.toList(): ListState<T> {
+    return mapChange({ MutableTrackedList(it.toMutableList()) }, { list, change ->
+        when (change) {
+            is TrackedSet.Add -> list.add(change.element)
+            is TrackedSet.Remove -> list.remove(change.element)
+            is TrackedSet.Clear -> list.clear()
+        }
+    })
+}
+
+fun <T> SetState<T>.filter(filter: (T) -> Boolean): SetState<T> =
+    mapChange({ MutableTrackedSet(it.filterTo(mutableSetOf(), filter)) }) { set, change ->
+        when (change) {
+            is TrackedSet.Add -> {
+                if (filter(change.element)) {
+                    set.add(change.element)
+                } else {
+                    set
+                }
+            }
+            is TrackedSet.Remove -> set.remove(change.element)
+            is TrackedSet.Clear -> set.clear()
+        }
+    }
+
+fun <T, U> SetState<T>.mapEach(mapper: (T) -> U): SetState<U> {
+    val mappedValues = mutableMapOf<T, U>()
+    val mappedCount = mutableMapOf<U, Int>()
+    val init = MutableTrackedSet(get().mapTo(mutableSetOf()) { value ->
+        mapper(value).also { mappedValue ->
+            mappedValues[value] = mappedValue
+            mappedCount.compute(mappedValue) { _, i -> (i ?: 0) + 1}
+        }
+    })
+    return mapChange({ init }) { list, change ->
+        when (change) {
+            is TrackedSet.Add -> {
+                val mappedValue = mapper(change.element)
+                mappedValues[change.element] = mappedValue
+                mappedCount.compute(mappedValue) { _, i -> (i ?: 0) + 1 }
+                list.add(mappedValue)
+            }
+            is TrackedSet.Remove -> {
+                val mappedValue = mappedValues.remove(change.element)!!
+                if (mappedCount.computeIfPresent(mappedValue) { _, i -> (i - 1).takeIf { i > 0 } } == null) {
+                    list.remove(mappedValue)
+                } else {
+                    list
+                }
+            }
+            is TrackedSet.Clear -> {
+                mappedValues.clear()
+                mappedCount.clear()
+                list.clear()
+            }
+        }
+    }
+}
+
+// TODO: all of these are based on mapSet and as such are quite inefficient, might make sense to implement some as efficient primitives instead
+
+fun <T, U> SetState<T>.mapSet(mapper: (Set<T>) -> Set<U>): SetState<U> =
+    map(mapper).toSetState()
+
+fun <T, U, V> SetState<T>.zipWithEachElement(otherState: State<U>, transform: (T, U) -> V) =
+    zip(otherState).map { (set, other) -> set.mapTo(mutableSetOf()) { transform(it, other) } }.toSetState()
+
+fun <T, U : Any> SetState<T>.mapEachNotNull(mapper: (T) -> U?) = mapSet { it.mapNotNullTo(mutableSetOf(), mapper) }
+
+fun <T : Any> SetState<T?>.filterNotNull() = mapSet { it.filterNotNullTo(mutableSetOf()) }
+
+inline fun <reified U> SetState<*>.filterIsInstance(): SetState<U> = map { it.filterIsInstanceTo<U, MutableSet<U>>(mutableSetOf()) }.toSetState()

--- a/src/main/kotlin/gg/essential/elementa/state/v2/state.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/state.kt
@@ -19,7 +19,7 @@ import java.lang.ref.WeakReference
  * Another advantage arises when using Kotlin, as States can be delegated to. For more information,
  * see delegation.kt.
  */
-interface State<T> {
+interface State<out T> {
   /** Get the value of this State object */
   fun get(): T
 

--- a/src/main/kotlin/gg/essential/elementa/state/v2/state.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/state.kt
@@ -1,0 +1,255 @@
+package gg.essential.elementa.state.v2
+
+import gg.essential.elementa.UIComponent
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+
+/**
+ * The base for all Elementa State objects.
+ *
+ * State objects are essentially just a wrapper around a value. However, the ability to be deeply
+ * integrated into an Elementa component allows some nice functionality.
+ *
+ * The primary advantage of using state is that a single state object can be shared between multiple
+ * components or constraints. This allows one value update to be seen by multiple components or
+ * constraints. For example, if a component has many text children, and they all share the same
+ * color state variable, then whenever the value of the state object is updated, all of the text
+ * components will instantly change color.
+ *
+ * Another advantage arises when using Kotlin, as States can be delegated to. For more information,
+ * see delegation.kt.
+ */
+interface State<T> {
+  /** Get the value of this State object */
+  fun get(): T
+
+  /**
+   * Register a listener which will be called whenever the value of this State object changes
+   *
+   * The listener registration is weak by default. This means that no strong reference to the
+   * listener is kept in this State object and your listener may be garbage collected if no other
+   * strong references to it exist. Once a listener is garbage collected, it will (obviously) no
+   * longer receive updates.
+   *
+   * Keeping a strong reference to your own listener is easy to forget, so this method requires you
+   * to explicitly pass in an object which will maintain a strong reference to your listener for
+   * you. With that, your listener will stay active **at least** as long as the given [owner] is
+   * alive (unless the returned callback in invoked).
+   *
+   * In general, the lifetime of your listener should match the lifetime of the passed [owner],
+   * usually the thing (e.g. [UIComponent]) the listener is modifying. If the owner far outlives
+   * your listener, you may be leaking memory because the owner will keep all those listeners and
+   * anything they reference alive far beyond the point where they are needed. If your listener
+   * outlives the owner, then it may become inactive sooner than you expected and whatever it is
+   * updating might no longer update properly.
+   *
+   * If you wish to manually keep your listener alive, pass [ReferenceHolder.Weak] as the owner.
+   *
+   * @return A callback which, when invoked, removes this listener
+   */
+  fun onSetValue(owner: ReferenceHolder, listener: (T) -> Unit): () -> Unit
+}
+
+/**
+ * Holds strong references to listeners to prevent them from being garbage collected.
+ * @see State.onSetValue
+ */
+interface ReferenceHolder {
+  fun holdOnto(listener: Any): () -> Unit
+
+  object Weak : ReferenceHolder {
+    override fun holdOnto(listener: Any): () -> Unit = {}
+  }
+}
+
+/** A [State] with a value that can be changed via [set] */
+@JvmDefaultWithoutCompatibility
+interface MutableState<T> : State<T> {
+  /**
+   * Update the value of this State object.
+   *
+   * After the value has been updated, all listeners of this State object are notified.
+   *
+   * The provided lambda must be a pure function which will return the new value for this State give
+   * the current value.
+   *
+   * Note that while most basic State implementations will call the lambda and notify listeners
+   * immediately, there is no general requirement for them to do so, and specialized State
+   * implementations may delay either or both to e.g. batch multiple updates together.
+   */
+  fun set(mapper: (T) -> T)
+
+  /**
+   * Update the value of this State object.
+   *
+   * After the value has been updated, all listeners of this State object are notified.
+   *
+   * Note that while most basic State implementations will update and notify listeners immediately,
+   * there is no general requirement for them to do so, and specialized State implementations may
+   * delay either or both to e.g. batch multiple updates together.
+   *
+   * @see [set]
+   */
+  fun set(value: T) = set { value }
+}
+
+/** A [State] delegating to a configurable target [State] */
+interface DelegatingState<T> : State<T> {
+  fun rebind(newState: State<T>)
+}
+
+/** A [MutableState] delegating to a configurable target [MutableState] */
+@JvmDefaultWithoutCompatibility
+interface DelegatingMutableState<T> : MutableState<T> {
+  fun rebind(newState: MutableState<T>)
+}
+
+/** Creates a new [State] with the given value. */
+fun <T> stateOf(value: T): State<T> = ImmutableState(value)
+
+/** Creates a new [MutableState] with the given initial value. */
+fun <T> mutableStateOf(value: T): MutableState<T> = BasicState(value)
+
+/** Creates a new [DelegatingState] with the given target [State]. */
+fun <T> stateDelegatingTo(state: State<T>): DelegatingState<T> = DelegatingStateImpl(state)
+
+/** Creates a new [DelegatingMutableState] with the given target [MutableState]. */
+fun <T> mutableStateDelegatingTo(state: MutableState<T>): DelegatingMutableState<T> =
+    DelegatingMutableStateImpl(state)
+
+/** Creates a [State] which derives its value in a user-defined way from one or more other states */
+fun <T> derivedState(
+    initialValue: T,
+    builder: (owner: ReferenceHolder, derivedState: MutableState<T>) -> Unit,
+): State<T> {
+  return ReferenceHoldingBasicState(initialValue).apply { builder(this, this) }
+}
+
+/** A simple, immutable implementation of [State] */
+private class ImmutableState<T>(private val value: T) : State<T> {
+  override fun get(): T = value
+  override fun onSetValue(owner: ReferenceHolder, listener: (T) -> Unit): () -> Unit = {}
+}
+
+/** A simple implementation of [MutableState], containing only a backing field */
+private open class BasicState<T>(private var valueBacker: T) : MutableState<T> {
+  private val referenceQueue = ReferenceQueue<Any>()
+  private val listeners = mutableListOf<ListenerEntry<T>>()
+
+  override fun get() = valueBacker
+
+  override fun onSetValue(owner: ReferenceHolder, listener: (T) -> Unit): () -> Unit {
+    cleanupStaleListeners()
+    val ownerCallback = WeakReference(owner.holdOnto(listener))
+    return ListenerEntry(this, listener, ownerCallback).also { listeners.add(it) }
+  }
+
+  override fun set(mapper: (T) -> T) {
+    val oldValue = valueBacker
+    val newValue = mapper(oldValue)
+    if (oldValue == newValue) {
+      return
+    }
+
+    valueBacker = newValue
+    listeners.forEach { it.get()?.invoke(newValue) }
+  }
+
+  private fun cleanupStaleListeners() {
+    while (true) {
+      val reference = referenceQueue.poll() ?: break
+      (reference as ListenerEntry<*>).invoke()
+    }
+  }
+
+  private class ListenerEntry<T>(
+      private val state: BasicState<T>,
+      listenerCallback: (T) -> Unit,
+      private val ownerCallback: WeakReference<() -> Unit>,
+  ) : WeakReference<(T) -> Unit>(listenerCallback, state.referenceQueue), () -> Unit {
+    override fun invoke() {
+      state.listeners.remove(this@ListenerEntry)
+      ownerCallback.get()?.invoke()
+    }
+  }
+}
+
+/** Base class for implementations of Delegating(Mutable)State classes. */
+private open class DelegatingStateBase<T, S : State<T>>(protected var delegate: S) : State<T> {
+  private val referenceQueue = ReferenceQueue<Any>()
+  private var listeners = mutableListOf<ListenerEntry<T>>()
+
+  override fun get(): T = delegate.get()
+
+  override fun onSetValue(owner: ReferenceHolder, listener: (T) -> Unit): () -> Unit {
+    cleanupStaleListeners()
+    val ownerCallback = WeakReference(owner.holdOnto(listener))
+    val removeCallback = delegate.onSetValue(ReferenceHolder.Weak, listener)
+    return ListenerEntry(this, listener, removeCallback, ownerCallback).also { listeners.add(it) }
+  }
+
+  fun rebind(newState: S) {
+    val oldState = delegate
+    if (oldState == newState) {
+      return
+    }
+
+    delegate = newState
+
+    listeners =
+        listeners.mapNotNullTo(mutableListOf()) { entry ->
+          entry.removeCallback()
+          val listenerCallback = entry.get() ?: return@mapNotNullTo null
+          val removeCallback = newState.onSetValue(ReferenceHolder.Weak, listenerCallback)
+          ListenerEntry(this, listenerCallback, removeCallback, entry.ownerCallback)
+        }
+
+    val oldValue = oldState.get()
+    val newValue = newState.get()
+    if (oldValue != newValue) {
+      listeners.forEach { it.get()?.invoke(newValue) }
+    }
+  }
+
+  private fun cleanupStaleListeners() {
+    while (true) {
+      val reference = referenceQueue.poll() ?: break
+      (reference as ListenerEntry<*>).invoke()
+    }
+  }
+
+  private class ListenerEntry<T>(
+      private val state: DelegatingStateBase<T, *>,
+      listenerCallback: (T) -> Unit,
+      val removeCallback: () -> Unit,
+      val ownerCallback: WeakReference<() -> Unit>,
+  ) : WeakReference<(T) -> Unit>(listenerCallback, state.referenceQueue), () -> Unit {
+    override fun invoke() {
+      state.listeners.remove(this@ListenerEntry)
+      removeCallback()
+      ownerCallback.get()?.invoke()
+    }
+  }
+}
+
+/** Default implementation of [DelegatingState] */
+private class DelegatingStateImpl<T>(delegate: State<T>) :
+    DelegatingStateBase<T, State<T>>(delegate), DelegatingState<T>
+
+/** Default implementation of [DelegatingMutableState] */
+private class DelegatingMutableStateImpl<T>(delegate: MutableState<T>) :
+    DelegatingStateBase<T, MutableState<T>>(delegate), DelegatingMutableState<T> {
+  override fun set(mapper: (T) -> T) {
+    delegate.set(mapper)
+  }
+}
+
+/** A [BasicState] which additionally implements [ReferenceHolder] */
+private class ReferenceHoldingBasicState<T>(value: T) : BasicState<T>(value), ReferenceHolder {
+  private val heldReferences = mutableListOf<Any>()
+
+  override fun holdOnto(listener: Any): () -> Unit {
+    heldReferences.add(listener)
+    return { heldReferences.remove(listener) }
+  }
+}

--- a/src/main/kotlin/gg/essential/elementa/state/v2/stateBy.kt
+++ b/src/main/kotlin/gg/essential/elementa/state/v2/stateBy.kt
@@ -1,0 +1,49 @@
+package gg.essential.elementa.state.v2
+
+/**
+ * Creates a state that derives its value using the given [block]. The value of any state may be accessed within this
+ * block via [StateByScope.invoke]. These accesses are tracked and the block is automatically re-evaluated whenever any
+ * one of them changes.
+ *
+ * Note that while this is generally easier to use than [derivedState], it also comes with greater overhead.
+ */
+fun <T> stateBy(block: StateByScope.() -> T): State<T> {
+    val subscribed = mutableMapOf<State<*>, () -> Unit>()
+    val observed = mutableSetOf<State<*>>()
+    val scope = object : StateByScope {
+        override fun <T> State<T>.invoke(): T {
+            observed.add(this)
+            return get()
+        }
+    }
+
+    return derivedState(initialValue = block(scope)) { owner, derivedState ->
+        fun updateSubscriptions() {
+            for (state in observed) {
+                if (state in subscribed) continue
+
+                subscribed[state] = state.onSetValue(owner) {
+                    val newValue = block(scope)
+                    updateSubscriptions()
+                    derivedState.set(newValue)
+                }
+            }
+
+            subscribed.entries.removeAll { (state, unregister) ->
+                if (state !in observed) {
+                    unregister()
+                    true
+                } else {
+                    false
+                }
+            }
+
+            observed.clear()
+        }
+        updateSubscriptions()
+    }
+}
+
+interface StateByScope {
+    operator fun <T> State<T>.invoke(): T
+}


### PR DESCRIPTION
Most significant changes compared to v1:
- `State` is now an interface instead of an abstract class
- `MutableState` is a separate interface and implementations are generally expected to forward `set` to their source states (whereas before, a `set` would only ever affect the state it was called on, and would frequently get overwritten if one of its input states changed)
- Listeners (and derived states) are weakly linked (as in `WeakReference`) by default, this allows a child component to transparently use the state of its parent without potentially leaking the child component memory
- The combinators no longer allow `rebind`ing (and no longer return special types; they are much simpler in general now), instead there's a dedicated `DelegatingState` which can be wrapped around an input where rebinding is required
- Combinator functions are now all extension functions (previously some of them were defined as part of `State` directly)
- New general `derivedState` builder function to create a state which is derived from any number of other states (all the combinators are based on this)

This new API should be fully compatible and be able to coexist with the legacy State API:
To use a v2 API with v1 states, the old `State` class extends the new `MutableState`, so people still using the old API can transparently use functionality designed for the new API.
To use a v1 API with v2 states, a old `State` instance can be created from a new `State` with the `State.toV1()` extension function.

As an example, the `MarkdownComponent` and the `PixelConstraint` have been converted to use/support the new v2 API for their existing functionality.