### PR TITLE
UIWrappedText: Constrain component height to render area

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/UIWrappedText.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIWrappedText.kt
@@ -78,15 +78,26 @@ open class UIWrappedText @JvmOverloads constructor(
     init {
         setWidth(textWidthState.pixels())
         setHeight(basicHeightConstraint {
+            val fontProvider = super.getFontProvider()
+
             val lines = getStringSplitToWidth(
                 getText(),
                 getWidth(),
                 getTextScale(),
                 ensureSpaceAtEndOfLines = false,
-                fontProvider = super.getFontProvider()
+                fontProvider = fontProvider,
             )
+            if (lines.isEmpty()) {
+                return@basicHeightConstraint 0f
+            }
 
-            (lines.size * lineSpacing + extraHeightState.get()) * getTextScale()
+            // The height of the last line of text should be equal the size of that text
+            // independent of the lineSpacing property. Otherwise, when lineSpacing is greater
+            // than the text height the component's size will be larger than the area the text
+            // is rendered
+            ((lines.size - 1) * lineSpacing + extraHeightState.get() // All lines but last
+                + (fontProvider.getBaseLineHeight() + fontProvider.getBelowLineHeight() + fontProvider.getShadowHeight()) // Last line
+                ) * getTextScale()
         })
     }
 


### PR DESCRIPTION
Previously, UIWrappedText's height would exceed the area it is rendered in when lineSpacing is greater than the size of each line