### PR TITLE
UIImage: Print stacktrace for erroneous images

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/UIImage.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIImage.kt
@@ -40,7 +40,10 @@ open class UIImage @JvmOverloads constructor(
     var textureMagFilter = TextureScalingMode.NEAREST
 
     init {
-        imageFuture.thenAcceptAsync {
+        imageFuture.exceptionally {
+            it.printStackTrace()
+            return@exceptionally null
+        }.thenAcceptAsync {
             if (it == null) {
                 destroy = false
                 return@thenAcceptAsync


### PR DESCRIPTION
Resolve #40 which talks of how UIImage's dont print exceptions because they have no exception handler nor utilise `CompleteableFuture#whenComplete`.

This PR resolves this by printing the exception IF the future throws an exception and returns the value as `null`,