### PR TITLE
RainbowColorConstraint: Fix color not changing automatically every frame

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/constraints/ColorConstraints.kt
+++ b/src/main/kotlin/gg/essential/elementa/constraints/ColorConstraints.kt
@@ -98,6 +98,7 @@ class RainbowColorConstraint(val alpha: Int = 255, val speed: Float = 50f) : Col
     }
 
     override fun animationFrame() {
+        super.animationFrame()
         currentStep++
 
         val red = ((sin((currentStep / speed).toDouble()) + 0.75) * 170).toInt()


### PR DESCRIPTION
Previously RainbowColorConstraint would only set its initial color since `recalculate` was never being toggled back to true, rather than updating every frame.