### PR TITLE
OverridableAlphaColorConstraint: Recalculate original constraint's color

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/effects/RecursiveFadeEffect.kt
+++ b/src/main/kotlin/gg/essential/elementa/effects/RecursiveFadeEffect.kt
@@ -62,8 +62,6 @@ class RecursiveFadeEffect constructor(
         override var constrainTo: UIComponent? = null
         override var recalculate = true
 
-        private var originalAlpha: Int? = null
-
         init {
             isOverridden.onSetValue {
                 recalculate = true
@@ -74,14 +72,17 @@ class RecursiveFadeEffect constructor(
             }
         }
 
+        override fun animationFrame() {
+            // We still want the original constraint's colour to recalculate while we are animating
+            originalConstraint.animationFrame()
+        }
+
         override fun getColorImpl(component: UIComponent): Color {
             val originalColor = originalConstraint.getColorImpl(component)
-
-            if (originalAlpha == null)
-                originalAlpha = originalColor.alpha
+            val originalAlpha = originalColor.alpha
 
             if (isOverridden.get())
-                return originalColor.withAlpha((originalAlpha!! * overriddenAlphaPercentage.get()).roundToInt().coerceIn(0, 255))
+                return originalColor.withAlpha((originalAlpha * overriddenAlphaPercentage.get()).roundToInt().coerceIn(0, 255))
             return originalColor
         }
 


### PR DESCRIPTION
We must forward the constraint's animation frame to the original. We want colors to be recalculated when needed and this prevents that during the `RecursiveFadeEffect`'s lifecycle.

The `originalAlpha` member was also removed. It didn't appear like there was any reason for caching the alpha, and a use-case where someone might depend on that is quite a niche one (neither I nor Johni could think of one), and its removal is required for this change to be effective.