### PR TITLE
Markdown bug fixes and small additions

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3152,7 +3152,8 @@ public final class gg/essential/elementa/markdown/MarkdownComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;)V
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;F)V
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;)V
-	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZLgg/essential/elementa/components/image/ImageCache;)V
 	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZLgg/essential/elementa/components/image/ImageCache;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun animationFrame ()V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3513,7 +3513,6 @@ public final class gg/essential/elementa/markdown/drawables/HardBreakDrawable : 
 
 public final class gg/essential/elementa/markdown/drawables/HeaderDrawable : gg/essential/elementa/markdown/drawables/Drawable {
 	public fun <init> (Lgg/essential/elementa/markdown/MarkdownComponent;ILgg/essential/elementa/markdown/drawables/ParagraphDrawable;)V
-	public fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
 	public fun cursorAt (FFZI)Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAtEnd ()Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAtStart ()Lgg/essential/elementa/markdown/selection/Cursor;
@@ -3572,7 +3571,6 @@ public final class gg/essential/elementa/markdown/drawables/ListDrawable$ListEnt
 
 public final class gg/essential/elementa/markdown/drawables/ParagraphDrawable : gg/essential/elementa/markdown/drawables/Drawable {
 	public fun <init> (Lgg/essential/elementa/markdown/MarkdownComponent;Lgg/essential/elementa/markdown/drawables/DrawableList;)V
-	public fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
 	public fun cursorAt (FFZI)Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAtEnd ()Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAtStart ()Lgg/essential/elementa/markdown/selection/Cursor;

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3153,13 +3153,14 @@ public final class gg/essential/elementa/markdown/MarkdownComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;F)V
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;)V
 	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZLgg/essential/elementa/components/image/ImageCache;)V
+	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZLgg/essential/elementa/components/image/ImageCache;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun animationFrame ()V
 	public final fun bindText (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/markdown/MarkdownComponent;
 	public fun draw (Lgg/essential/universal/UMatrixStack;)V
 	public final fun getConfig ()Lgg/essential/elementa/markdown/MarkdownConfig;
 	public final fun getDrawables ()Lgg/essential/elementa/markdown/drawables/DrawableList;
+	public final fun getImageCache ()Lgg/essential/elementa/components/image/ImageCache;
 	public final fun getMaxTextLineWidth ()F
 	public final fun getSectionOffsets ()Ljava/util/Map;
 	public final fun layout ()V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3236,19 +3236,22 @@ public final class gg/essential/elementa/markdown/ParagraphConfig {
 	public fun <init> (FFF)V
 	public fun <init> (FFFZ)V
 	public fun <init> (FFFZZ)V
-	public synthetic fun <init> (FFFZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (FFFZZF)V
+	public synthetic fun <init> (FFFZZFILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()F
 	public final fun component2 ()F
 	public final fun component3 ()F
 	public final fun component4 ()Z
 	public final fun component5 ()Z
-	public final fun copy (FFFZZ)Lgg/essential/elementa/markdown/ParagraphConfig;
-	public static synthetic fun copy$default (Lgg/essential/elementa/markdown/ParagraphConfig;FFFZZILjava/lang/Object;)Lgg/essential/elementa/markdown/ParagraphConfig;
+	public final fun component6 ()F
+	public final fun copy (FFFZZF)Lgg/essential/elementa/markdown/ParagraphConfig;
+	public static synthetic fun copy$default (Lgg/essential/elementa/markdown/ParagraphConfig;FFFZZFILjava/lang/Object;)Lgg/essential/elementa/markdown/ParagraphConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCentered ()Z
 	public final fun getSoftBreakIsNewline ()Z
 	public final fun getSpaceAfter ()F
 	public final fun getSpaceBefore ()F
+	public final fun getSpaceBetweenImages ()F
 	public final fun getSpaceBetweenLines ()F
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3338,6 +3341,7 @@ public abstract class gg/essential/elementa/markdown/drawables/Drawable {
 	public static final field Companion Lgg/essential/elementa/markdown/drawables/Drawable$Companion;
 	public field layout Lgg/essential/elementa/markdown/drawables/Drawable$Layout;
 	public fun <init> (Lgg/essential/elementa/markdown/MarkdownComponent;)V
+	public fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
 	public abstract fun cursorAt (FFZI)Lgg/essential/elementa/markdown/selection/Cursor;
 	public abstract fun cursorAtEnd ()Lgg/essential/elementa/markdown/selection/Cursor;
 	public abstract fun cursorAtStart ()Lgg/essential/elementa/markdown/selection/Cursor;
@@ -3509,6 +3513,7 @@ public final class gg/essential/elementa/markdown/drawables/HardBreakDrawable : 
 
 public final class gg/essential/elementa/markdown/drawables/HeaderDrawable : gg/essential/elementa/markdown/drawables/Drawable {
 	public fun <init> (Lgg/essential/elementa/markdown/MarkdownComponent;ILgg/essential/elementa/markdown/drawables/ParagraphDrawable;)V
+	public fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
 	public fun cursorAt (FFZI)Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAtEnd ()Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAtStart ()Lgg/essential/elementa/markdown/selection/Cursor;
@@ -3521,6 +3526,7 @@ public final class gg/essential/elementa/markdown/drawables/HeaderDrawable : gg/
 
 public final class gg/essential/elementa/markdown/drawables/ImageDrawable : gg/essential/elementa/markdown/drawables/Drawable {
 	public fun <init> (Lgg/essential/elementa/markdown/MarkdownComponent;Ljava/net/URL;Lgg/essential/elementa/markdown/drawables/Drawable;)V
+	public fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
 	public synthetic fun cursorAt (FFZI)Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAt (FFZI)Ljava/lang/Void;
 	public synthetic fun cursorAtEnd ()Lgg/essential/elementa/markdown/selection/Cursor;
@@ -3528,6 +3534,7 @@ public final class gg/essential/elementa/markdown/drawables/ImageDrawable : gg/e
 	public synthetic fun cursorAtStart ()Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAtStart ()Lgg/essential/elementa/markdown/selection/ImageCursor;
 	public fun draw (Lgg/essential/universal/UMatrixStack;Lgg/essential/elementa/markdown/DrawState;)V
+	public final fun getImageWidth ()F
 	public final fun getSelected ()Z
 	public final fun getUrl ()Ljava/net/URL;
 	public fun hasSelectedText ()Z
@@ -3565,6 +3572,7 @@ public final class gg/essential/elementa/markdown/drawables/ListDrawable$ListEnt
 
 public final class gg/essential/elementa/markdown/drawables/ParagraphDrawable : gg/essential/elementa/markdown/drawables/Drawable {
 	public fun <init> (Lgg/essential/elementa/markdown/MarkdownComponent;Lgg/essential/elementa/markdown/drawables/DrawableList;)V
+	public fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
 	public fun cursorAt (FFZI)Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAtEnd ()Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAtStart ()Lgg/essential/elementa/markdown/selection/Cursor;
@@ -3590,7 +3598,7 @@ public final class gg/essential/elementa/markdown/drawables/SoftBreakDrawable : 
 public final class gg/essential/elementa/markdown/drawables/TextDrawable : gg/essential/elementa/markdown/drawables/Drawable {
 	public static final field Companion Lgg/essential/elementa/markdown/drawables/TextDrawable$Companion;
 	public fun <init> (Lgg/essential/elementa/markdown/MarkdownComponent;Ljava/lang/String;Lgg/essential/elementa/markdown/drawables/TextDrawable$Style;)V
-	public final fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
+	public fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
 	public synthetic fun cursorAt (FFZI)Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAt (FFZI)Ljava/lang/Void;
 	public synthetic fun cursorAtEnd ()Lgg/essential/elementa/markdown/selection/Cursor;

--- a/src/main/java/com/example/examplemod/ExamplesGui.kt
+++ b/src/main/java/com/example/examplemod/ExamplesGui.kt
@@ -56,6 +56,7 @@ class ExamplesGui : WindowScreen(ElementaVersion.V2) {
         val examples = mutableMapOf<String, () -> UScreen>(
             "ExampleGui" to ::ExampleGui,
             "ComponentsGui" to ::ComponentsGui,
+            "MarkdownTestGui" to ::MarkdownTestGui
         )
     }
 }

--- a/src/main/java/com/example/examplemod/MarkdownTestGui.kt
+++ b/src/main/java/com/example/examplemod/MarkdownTestGui.kt
@@ -1,0 +1,32 @@
+package com.example.examplemod
+
+import gg.essential.elementa.ElementaVersion
+import gg.essential.elementa.WindowScreen
+import gg.essential.elementa.components.ScrollComponent
+import gg.essential.elementa.constraints.CenterConstraint
+import gg.essential.elementa.dsl.childOf
+import gg.essential.elementa.dsl.constrain
+import gg.essential.elementa.dsl.percent
+import gg.essential.elementa.dsl.pixels
+import gg.essential.elementa.markdown.MarkdownComponent
+
+class MarkdownTestGui : WindowScreen(ElementaVersion.V2) {
+    init {
+        val scrollBox = ScrollComponent().constrain {
+            width = 100.percent()
+            height = 100.percent()
+        } childOf window
+
+        MarkdownComponent(
+            "# Markdown Test" +
+                    "\n![](https://picsum.photos/800/300)" +
+                    "\nBig image" +
+                    "\n\n![](https://picsum.photos/225)![](https://picsum.photos/225)![](https://picsum.photos/225) Small images with text that wraps directly after it."
+        ).constrain {
+            x = CenterConstraint()
+            y = 0.pixels()
+            width = 800.pixels()
+            height = 100.percent()
+        } childOf scrollBox
+    }
+}

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -44,7 +44,8 @@ class MarkdownComponent(
         config: MarkdownConfig = MarkdownConfig(),
         codeFontPointSize: Float = 10f,
         codeFontRenderer: FontProvider = ElementaFonts.JETBRAINS_MONO,
-    ) : this(text, config, codeFontPointSize, codeFontRenderer, false)
+        disableSelection: Boolean = false,
+    ) : this(text, config, codeFontPointSize, codeFontRenderer, disableSelection, null)
 
     private val configState = BasicState(config)
     val config: MarkdownConfig

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -166,7 +166,9 @@ class MarkdownComponent(
         maxTextLineWidth = drawables.maxOfOrNull { drawable ->
             when (drawable) {
                 is ParagraphDrawable -> drawable.maxTextLineWidth
-                is HeaderDrawable -> drawable.children.filterIsInstance<ParagraphDrawable>().maxOfOrNull { it.maxTextLineWidth } ?: 0f
+                is HeaderDrawable -> drawable.children.filterIsInstance<ParagraphDrawable>()
+                    .maxOfOrNull { it.maxTextLineWidth } ?: 0f
+
                 is ListDrawable -> drawable.maxTextLineWidth
                 is BlockquoteDrawable -> drawable.maxTextLineWidth
                 else -> 0f
@@ -194,7 +196,7 @@ class MarkdownComponent(
     /**
      * Updates the MarkdownConfig this component uses.
      */
-    fun updateConfig(config: MarkdownConfig)  {
+    fun updateConfig(config: MarkdownConfig) {
         configState.set(config)
     }
 
@@ -219,12 +221,14 @@ class MarkdownComponent(
         val drawState = DrawState(getLeft() - baseX, getTop() - baseY)
         val parentWindow = Window.of(this)
 
-        drawables.forEach {
+        drawables.forEach { it.beforeDraw(drawState) }
 
+        drawables.forEach {
             if (!parentWindow.isAreaVisible(
                     it.layout.left.toDouble() + drawState.xShift, it.layout.top.toDouble() + drawState.yShift,
                     it.layout.right.toDouble() + drawState.xShift, it.layout.bottom.toDouble() + drawState.yShift
-            )) return@forEach
+                )
+            ) return@forEach
 
             if (elementaDebug) {
                 drawDebugOutline(

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -5,6 +5,7 @@ import gg.essential.elementa.components.MarkdownNode
 import gg.essential.elementa.components.TreeListComponent
 import gg.essential.elementa.components.TreeNode
 import gg.essential.elementa.components.Window
+import gg.essential.elementa.components.image.ImageCache
 import gg.essential.elementa.constraints.HeightConstraint
 import gg.essential.elementa.dsl.pixels
 import gg.essential.elementa.events.UIEvent
@@ -34,6 +35,7 @@ class MarkdownComponent(
     private val codeFontPointSize: Float = 10f,
     private val codeFontRenderer: FontProvider = ElementaFonts.JETBRAINS_MONO,
     private val disableSelection: Boolean = false,
+    val imageCache: ImageCache? = null
 ) : UIComponent() {
 
     @JvmOverloads

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownConfig.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownConfig.kt
@@ -52,7 +52,8 @@ data class ParagraphConfig @JvmOverloads constructor(
     val spaceBefore: Float = 5f,
     val spaceAfter: Float = 5f,
     val softBreakIsNewline: Boolean = false,
-    val centered: Boolean = false
+    val centered: Boolean = false,
+    val spaceBetweenImages: Float = 4f
 )
 
 data class TextConfig @JvmOverloads constructor(

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/Drawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/Drawable.kt
@@ -75,7 +75,9 @@ abstract class Drawable(val md: MarkdownComponent) {
     open fun draw(matrixStack: UMatrixStack, state: DrawState) {
     }
 
-    open fun beforeDraw(state: DrawState) {}
+    open fun beforeDraw(state: DrawState) {
+        children.forEach { it.beforeDraw(state) }
+    }
 
     fun isHovered(mouseX: Float, mouseY: Float): Boolean {
         return mouseX in layout.left..layout.right && mouseY in layout.top..layout.bottom

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/Drawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/Drawable.kt
@@ -4,7 +4,6 @@ import gg.essential.elementa.markdown.DrawState
 import gg.essential.elementa.markdown.MarkdownComponent
 import gg.essential.elementa.markdown.MarkdownConfig
 import gg.essential.elementa.markdown.selection.Cursor
-import gg.essential.elementa.markdown.selection.TextCursor
 import gg.essential.universal.UMatrixStack
 import kotlin.reflect.KMutableProperty0
 import kotlin.reflect.KProperty

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/Drawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/Drawable.kt
@@ -76,6 +76,8 @@ abstract class Drawable(val md: MarkdownComponent) {
     open fun draw(matrixStack: UMatrixStack, state: DrawState) {
     }
 
+    open fun beforeDraw(state: DrawState) {}
+
     fun isHovered(mouseX: Float, mouseY: Float): Boolean {
         return mouseX in layout.left..layout.right && mouseY in layout.top..layout.bottom
     }

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/HeaderDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/HeaderDrawable.kt
@@ -68,10 +68,6 @@ class HeaderDrawable(
         }
     }
 
-    override fun beforeDraw(state: DrawState) {
-        paragraph.beforeDraw(state)
-    }
-
     override fun cursorAt(mouseX: Float, mouseY: Float, dragged: Boolean, mouseButton: Int) = paragraph.cursorAt(mouseX, mouseY, dragged, mouseButton)
     override fun cursorAtStart() = paragraph.cursorAtStart()
     override fun cursorAtEnd() = paragraph.cursorAtEnd()

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/HeaderDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/HeaderDrawable.kt
@@ -59,13 +59,17 @@ class HeaderDrawable(
             val y = layout.bottom - layout.margin.bottom - headerConfig.dividerWidth
             UIBlock.drawBlockSized(
                 matrixStack,
-                headerConfig.dividerColor, 
+                headerConfig.dividerColor,
                 (x + state.xShift).toDouble(),
                 (y + state.yShift).toDouble(),
                 dividerWidth ?: width.toDouble(),
                 headerConfig.dividerWidth.toDouble()
             )
         }
+    }
+
+    override fun beforeDraw(state: DrawState) {
+        paragraph.beforeDraw(state)
     }
 
     override fun cursorAt(mouseX: Float, mouseY: Float, dragged: Boolean, mouseButton: Int) = paragraph.cursorAt(mouseX, mouseY, dragged, mouseButton)

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ImageDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ImageDrawable.kt
@@ -30,7 +30,8 @@ class ImageDrawable(md: MarkdownComponent, val url: URL, private val fallback: D
     private lateinit var imageX: ShiftableMDPixelConstraint
     private lateinit var imageY: ShiftableMDPixelConstraint
 
-    private val image = UIImage.ofURL(url) childOf md
+    private val image =
+        (if (md.imageCache == null) UIImage.ofURL(url) else UIImage.ofURL(url, md.imageCache)) childOf md
     private var hasLoaded = false
 
     override fun layoutImpl(x: Float, y: Float, width: Float): Layout {

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -81,8 +81,6 @@ class ParagraphDrawable(
         var maxLineHeight = Float.MIN_VALUE
 
         fun gotoNextLine() {
-            if (parent is HeaderDrawable) println("new line")
-
             currX = x
             currY += maxLineHeight + config.paragraphConfig.spaceBetweenLines
 
@@ -299,10 +297,6 @@ class ParagraphDrawable(
                 layout.elementHeight.toDouble()
             )
         }
-    }
-
-    override fun beforeDraw(state: DrawState) {
-        drawables.forEach { it.beforeDraw(state) }
     }
 
     override fun cursorAt(mouseX: Float, mouseY: Float, dragged: Boolean, mouseButton: Int): Cursor<*> {

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -156,11 +156,9 @@ class ParagraphDrawable(
             }
 
             if (text is ImageDrawable) {
-                //if (currentLine.isNotEmpty()) gotoNextLine()
                 if (widthRemaining - text.getImageWidth() <= 0)
                     gotoNextLine()
                 layout(text, width)
-                //gotoNextLine()
                 continue
             }
 

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -1,7 +1,6 @@
 package gg.essential.elementa.markdown.drawables
 
 import gg.essential.elementa.components.UIBlock
-import gg.essential.elementa.components.UIImage
 import gg.essential.elementa.dsl.width
 import gg.essential.elementa.markdown.DrawState
 import gg.essential.elementa.markdown.HeaderLevelConfig

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
@@ -129,7 +129,7 @@ class TextDrawable(
         )
     }
 
-    fun beforeDraw(state: DrawState) {
+    override fun beforeDraw(state: DrawState) {
         texts.clear()
 
         if (selectionStart == -1 && selectionEnd == -1) {


### PR DESCRIPTION
 - Fixed images not moving text after it down accordingly
 - Fixed not being able to have 2 images or an image and text on the same line
 - Fixed images moving delayed while moved with a scroll component
 - Added beforedraw method to Drawable for consitency
 - Fixed images flickering after being loaded
 - Fixed images staying in place when scrolling fast
 - Fixed size of markdown component being being a line smaller then in reality
 - Add ability to specify image cache