### PR TITLE
TextDrawable: Fix incorrect splitting of formatted drawables

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
@@ -83,11 +83,11 @@ class TextDrawable(
         splitPoint -= styleChars
 
         if (!breakWords) {
-            while (splitPoint > styleChars && formattedText[splitPoint] != ' ') {
+            while (splitPoint > 0 && plainText[splitPoint] != ' ') {
                 splitPoint--
             }
 
-            if (splitPoint == styleChars) {
+            if (splitPoint == 0) {
                 return null
             }
         }


### PR DESCRIPTION
After styleChars is subtracted from splitPoint, the splitPoint value refers to indices in the plainText, not the formattedText.

Fixes EM-1599

Before: 
![Before image](https://user-images.githubusercontent.com/52044242/235538836-c2701e0e-9ec5-4dc8-b061-cb601e04f4cc.png)

After:
![After image](https://user-images.githubusercontent.com/52044242/235538865-37983da6-bdb1-45df-965d-ae0434f94783.png)

