### PR TITLE
Window: Fix incorrect `animationFrames` computation

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/Window.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/Window.kt
@@ -82,7 +82,7 @@ class Window @JvmOverloads constructor(
                 this.systemTime = System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(5)
 
             val target = System.currentTimeMillis() + 1000 / animationFPS
-            val animationFrames = (target - this.systemTime).toInt() / animationFPS
+            val animationFrames = (target - this.systemTime).toInt() * animationFPS / 1000
             // If the window is sufficiently complex, it's possible for the average `animationFrame` to take so long
             // we'll start falling behind with no way to ever catch up. And the amount of frames we're behind will
             // quickly grow to the point where we'll be spending five seconds in `animationFrame` before we can get a


### PR DESCRIPTION
We expect the `animationFrames` variable to contain the amount of frames to run but what we used to compute does not even have the correct units: `ms / (frames / sec)`

This wasn't immediately obvious because the further we drift from the target, the closer this value actually becomes to the correct value, so after just a few seconds it was no longer noticeable.

This commit fixes that. The new computation is
`ms * (frames / sec) / (ms / sec) = ms * frames / sec * sec / ms` which all nicely cancels out leaving us with only `frames` as expected.