### PR TITLE
Markdown: fix images flickering when loading and lagging behind when scrolling

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3338,6 +3338,7 @@ public abstract class gg/essential/elementa/markdown/drawables/Drawable {
 	public static final field Companion Lgg/essential/elementa/markdown/drawables/Drawable$Companion;
 	public field layout Lgg/essential/elementa/markdown/drawables/Drawable$Layout;
 	public fun <init> (Lgg/essential/elementa/markdown/MarkdownComponent;)V
+	public fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
 	public abstract fun cursorAt (FFZI)Lgg/essential/elementa/markdown/selection/Cursor;
 	public abstract fun cursorAtEnd ()Lgg/essential/elementa/markdown/selection/Cursor;
 	public abstract fun cursorAtStart ()Lgg/essential/elementa/markdown/selection/Cursor;
@@ -3521,6 +3522,7 @@ public final class gg/essential/elementa/markdown/drawables/HeaderDrawable : gg/
 
 public final class gg/essential/elementa/markdown/drawables/ImageDrawable : gg/essential/elementa/markdown/drawables/Drawable {
 	public fun <init> (Lgg/essential/elementa/markdown/MarkdownComponent;Ljava/net/URL;Lgg/essential/elementa/markdown/drawables/Drawable;)V
+	public fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
 	public synthetic fun cursorAt (FFZI)Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAt (FFZI)Ljava/lang/Void;
 	public synthetic fun cursorAtEnd ()Lgg/essential/elementa/markdown/selection/Cursor;
@@ -3590,7 +3592,7 @@ public final class gg/essential/elementa/markdown/drawables/SoftBreakDrawable : 
 public final class gg/essential/elementa/markdown/drawables/TextDrawable : gg/essential/elementa/markdown/drawables/Drawable {
 	public static final field Companion Lgg/essential/elementa/markdown/drawables/TextDrawable$Companion;
 	public fun <init> (Lgg/essential/elementa/markdown/MarkdownComponent;Ljava/lang/String;Lgg/essential/elementa/markdown/drawables/TextDrawable$Style;)V
-	public final fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
+	public fun beforeDraw (Lgg/essential/elementa/markdown/DrawState;)V
 	public synthetic fun cursorAt (FFZI)Lgg/essential/elementa/markdown/selection/Cursor;
 	public fun cursorAt (FFZI)Ljava/lang/Void;
 	public synthetic fun cursorAtEnd ()Lgg/essential/elementa/markdown/selection/Cursor;

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -219,6 +219,8 @@ class MarkdownComponent(
         val drawState = DrawState(getLeft() - baseX, getTop() - baseY)
         val parentWindow = Window.of(this)
 
+        drawables.forEach { it.beforeDraw(drawState) }
+
         drawables.forEach {
 
             if (!parentWindow.isAreaVisible(

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/Drawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/Drawable.kt
@@ -76,6 +76,10 @@ abstract class Drawable(val md: MarkdownComponent) {
     open fun draw(matrixStack: UMatrixStack, state: DrawState) {
     }
 
+    open fun beforeDraw(state: DrawState) {
+        children.forEach { it.beforeDraw(state) }
+    }
+
     fun isHovered(mouseX: Float, mouseY: Float): Boolean {
         return mouseX in layout.left..layout.right && mouseY in layout.top..layout.bottom
     }

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ImageDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ImageDrawable.kt
@@ -52,17 +52,21 @@ class ImageDrawable(md: MarkdownComponent, val url: URL, private val fallback: D
     }
 
     override fun draw(matrixStack: UMatrixStack, state: DrawState) {
-        if (!image.isLoaded) {
+        if (!hasLoaded) {
             fallback.drawCompat(matrixStack, state)
         } else {
-            if (!hasLoaded) {
-                hasLoaded = true
-                md.layout()
-            }
+            image.drawCompat(matrixStack)
+        }
+    }
 
+    override fun beforeDraw(state: DrawState) {
+        if (image.isLoaded && !hasLoaded) {
+            hasLoaded = true
+            md.layout()
+        }
+        if (hasLoaded) {
             imageX.shift = state.xShift
             imageY.shift = state.yShift
-            image.drawCompat(matrixStack)
         }
     }
 
@@ -83,7 +87,12 @@ class ImageDrawable(md: MarkdownComponent, val url: URL, private val fallback: D
     // TODO: Rename this function?
     override fun hasSelectedText() = selected
 
-    private inner class ShiftableMDPixelConstraint(val base: Float, var shift: Float) : XConstraint, YConstraint {
+    private inner class ShiftableMDPixelConstraint(val base: Float, shift: Float) : XConstraint, YConstraint {
+        var shift: Float = shift
+            set(value) {
+                recalculate = true
+                field = value
+            }
         override var cachedValue = 0f
         override var recalculate = true
         override var constrainTo: UIComponent? = null

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -278,7 +278,6 @@ class ParagraphDrawable(
     }
 
     override fun draw(matrixStack: UMatrixStack, state: DrawState) {
-        drawables.filterIsInstance<TextDrawable>().forEach { it.beforeDraw(state) }
         drawables.forEach { it.drawCompat(matrixStack, state) }
 
         // TODO: Remove

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/TextDrawable.kt
@@ -129,7 +129,7 @@ class TextDrawable(
         )
     }
 
-    fun beforeDraw(state: DrawState) {
+    override fun beforeDraw(state: DrawState) {
         texts.clear()
 
         if (selectionStart == -1 && selectionEnd == -1) {


### PR DESCRIPTION
- Run necessary things related to location before drawing anything, fixes images lagging behind when mouse is hovering it and flickering when image just loaded
- Create `beforeDraw` function in `Drawable` since `TextDrawable` already had something like it and keeping it separate everywhere could result in a mess