### PR TITLE
ScrollComponent: Fix duplicate emptyText

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -595,7 +595,7 @@ class ScrollComponent @JvmOverloads constructor(
         actualHolder.removeChild(component)
         allChildren.remove(component)
 
-        if (allChildren.isEmpty())
+        if (actualHolder.children.isEmpty())
             actualHolder.addChild(emptyText)
 
         needsUpdate = true


### PR DESCRIPTION
When a child is removed from the scroller via `removeChild`, we used to check if no children were left and if that was the case, we'd assume that the last child was just removed and therefore we need to add the `emptyText` back. This assumption however is incorrect when one considers `filterChildren` which too might add the `emptyText` if it filters out everything. In that case the empty text is already in the `actualHolder` and this code just adds a second one.

And even the next `addChild` will only remove one of the two, leaving you with mixed content which will likely blow up your comparator if you then try to `sortChildren`.

This commit fixes the issue by checking whether `actualHolder.children` is actually empty before adding the `emptyText`.

Fixes EM-1455