### PR TITLE
Build: Update to Gradle 8.2, Loom 1.2

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -9,6 +9,8 @@ public final class gg/essential/elementa/ElementaVersion : java/lang/Enum {
 }
 
 public final class gg/essential/elementa/ElementaVersion$Companion {
+	public final fun getActive ()Lgg/essential/elementa/ElementaVersion;
+	public final fun setActive (Lgg/essential/elementa/ElementaVersion;)V
 }
 
 public abstract class gg/essential/elementa/UIComponent : java/util/Observable, gg/essential/elementa/state/v2/ReferenceHolder {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 
-# Need Java 16, and this seems to be the easiest way to do that per-branch for TeamCity
+# Need Java 17, and this seems to be the easiest way to do that per-branch for TeamCity
 if [ -n "$IS_CI" ]; then
-    JAVA_HOME=/usr/lib/jvm/java-16-oracle
+    JAVA_HOME=/usr/lib/jvm/jdk-17.0.2
 fi
 
 #

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
         maven("https://repo.essential.gg/repository/maven-public")
     }
     plugins {
-        val egtVersion = "0.1.9"
+        val egtVersion = "0.2.2"
         id("gg.essential.defaults") version egtVersion
         id("gg.essential.multi-version.root") version egtVersion
         id("gg.essential.multi-version.api-validation") version egtVersion

--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
         }
         fabricApiModules.forEach { module ->
             // Using this combo to add it to our deps but not to our maven publication cause it's only for the example
-            modRuntime(modCompileOnly(fabricApi.module("fabric-$module", fabricApiVersion))!!)
+            modLocalRuntime(modCompileOnly(fabricApi.module("fabric-$module", fabricApiVersion))!!)
         }
     }
 }


### PR DESCRIPTION
The changes to the API dump are presumably due to a bug fix in the Kotlin binary compatibility validator.