### PR TITLE
UIComponent: Call `afterDraw` on effects in reverse-order

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3,6 +3,7 @@ public final class gg/essential/elementa/ElementaVersion : java/lang/Enum {
 	public static final field V0 Lgg/essential/elementa/ElementaVersion;
 	public static final field V1 Lgg/essential/elementa/ElementaVersion;
 	public static final field V2 Lgg/essential/elementa/ElementaVersion;
+	public static final field V3 Lgg/essential/elementa/ElementaVersion;
 	public final fun enableFor (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static fun valueOf (Ljava/lang/String;)Lgg/essential/elementa/ElementaVersion;
 	public static fun values ()[Lgg/essential/elementa/ElementaVersion;

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -61,7 +61,12 @@ enum class ElementaVersion {
     V2,
 
     /**
-     * [gg.essential.elementa.UIComponent.afterDraw] is now called in the opposite order to [gg.essential.elementa.UIComponent.beforeDraw].
+     * When there are multiple [gg.essential.elementa.effects.Effect] applied to a single component, their [gg.essential.elementa.effects.Effect.afterDraw]
+     * are now called in reverse order, such that they form a stack around the draw itself:
+     * `effectA.beforeDraw effectB.beforeDraw component.draw effectB.afterDraw effectA.afterDraw`
+     *
+     * Prior versions called `effectA.afterDraw` before `effectB.afterDraw` which could result in inproper cleanup when
+     * both effects modify the same thing.
      */
     V3,
 

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -57,7 +57,13 @@ enum class ElementaVersion {
      * override of that method. If you do, then you should switch to using the new override at the same time as you
      * upgrade to the new version (or override both if you need to maintain support for old versions).
      */
+    @Deprecated(DEPRECATION_MESSAGE)
     V2,
+
+    /**
+     * [gg.essential.elementa.UIComponent.afterDraw] is now called in the opposite order to [gg.essential.elementa.UIComponent.beforeDraw].
+     */
+    V3,
 
     ;
 
@@ -95,6 +101,8 @@ Be sure to read through all the changes between your current version and your ne
         internal val v1 = V1
         @Suppress("DEPRECATION")
         internal val v2 = V2
+        @Suppress("DEPRECATION")
+        internal val v3 = V3
 
 
         @PublishedApi

--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -513,7 +513,7 @@ abstract class UIComponent : Observable(), ReferenceHolder {
     }
 
     open fun afterDraw(matrixStack: UMatrixStack) {
-        if ((Window.ofOrNull(this)?.version ?: ElementaVersion.v0) >= ElementaVersion.v3) {
+        if (ElementaVersion.active >= ElementaVersion.v3) {
             effects.asReversed().forEach { it.afterDraw(matrixStack) }
         } else {
             effects.forEach { it.afterDraw(matrixStack) }

--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -513,7 +513,11 @@ abstract class UIComponent : Observable(), ReferenceHolder {
     }
 
     open fun afterDraw(matrixStack: UMatrixStack) {
-        effects.forEach { it.afterDraw(matrixStack) }
+        if ((Window.ofOrNull(this)?.version ?: ElementaVersion.v0) >= ElementaVersion.v3) {
+            effects.asReversed().forEach { it.afterDraw(matrixStack) }
+        } else {
+            effects.forEach { it.afterDraw(matrixStack) }
+        }
     }
 
     open fun beforeChildrenDraw(matrixStack: UMatrixStack) {


### PR DESCRIPTION
Prior to this, if you had two effects (e.g. ScissorEffect) of the same type on the same component, they would clash due to `afterDraw` being called in the same order as `beforeDraw`. Calling `afterDraw` on these effects in reverse solves the problem.

This also introduces a new Elementa version, V3 - which deprecates V2.