### PR TITLE
ScrollComponent: Change DefaultScrollBar to be a UIContainer

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -655,7 +655,7 @@ class ScrollComponent @JvmOverloads constructor(
     private fun ClosedFloatingPointRange<Double>.width() = abs(this.start - this.endInclusive)
     private fun ClosedFloatingPointRange<Float>.width() = abs(this.start - this.endInclusive)
 
-    class DefaultScrollBar(isHorizontal: Boolean) : UIComponent() {
+    class DefaultScrollBar(isHorizontal: Boolean) : UIContainer() {
         val grip: UIComponent
 
         init {


### PR DESCRIPTION
This makes sure that the `beforeDraw` method is called.