### PR TITLE
Misc: Fix build reference badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,48 +59,48 @@ modImplementation(include("gg.essential:elementa-$mcVersion-$mcPlatform:$buildNu
           <td>1.18.1</td>
           <td>fabric</td>
           <td>
-            <img alt="1.18.1-fabric" src="https://badges.modcore.net/badge/dynamic/xml?color=A97BFF&label=%20&query=%2Fmetadata%2Fversioning%2Flatest&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.18.1-fabric/maven-metadata.xml">
+            <img alt="1.18.1-fabric" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.18.1-fabric/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.18.1</td>
           <td>forge</td>
           <td>
-            <img alt="1.18.1-forge" src="https://badges.modcore.net/badge/dynamic/xml?color=A97BFF&label=%20&query=%2Fmetadata%2Fversioning%2Flatest&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.18.1-forge/maven-metadata.xml">
+            <img alt="1.18.1-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.18.1-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.17.1</td>
           <td>fabric</td>
           <td>
-            <img alt="1.17.1-fabric" src="https://badges.modcore.net/badge/dynamic/xml?color=A97BFF&label=%20&query=%2Fmetadata%2Fversioning%2Flatest&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.17.1-fabric/maven-metadata.xml">
+            <img alt="1.17.1-fabric" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.17.1-fabric/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.17.1</td>
           <td>forge</td>
           <td>
-            <img alt="1.17.1-forge" src="https://badges.modcore.net/badge/dynamic/xml?color=A97BFF&label=%20&query=%2Fmetadata%2Fversioning%2Flatest&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.17.1-forge/maven-metadata.xml">
+            <img alt="1.17.1-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.17.1-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.16.2</td>
           <td>forge</td>
           <td>
-            <img alt="1.16.2-forge" src="https://badges.modcore.net/badge/dynamic/xml?color=A97BFF&label=%20&query=%2Fmetadata%2Fversioning%2Flatest&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.16.2-forge/maven-metadata.xml">
+            <img alt="1.16.2-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.16.2-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.12.2</td>
           <td>forge</td>
           <td>
-            <img alt="1.12.2-forge" src="https://badges.modcore.net/badge/dynamic/xml?color=A97BFF&label=%20&query=%2Fmetadata%2Fversioning%2Flatest&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.12.2-forge/maven-metadata.xml">
+            <img alt="1.12.2-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.12.2-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.8.9</td>
           <td>forge</td>
-          <td><img alt="1.8.9-forge" src="https://badges.modcore.net/badge/dynamic/xml?color=A97BFF&label=%20&query=%2Fmetadata%2Fversioning%2Flatest&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.8.9-forge/maven-metadata.xml"></td>
+          <td><img alt="1.8.9-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.8.9-forge/maven-metadata.xml"></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
Turns out we still used the badges.modcore.net service even though we didn't use any of its authenticated services. We are able to move to the public shields.io instance without any changes.

This also fixes pull request builds showing in the build reference by filtering for the version with the following XPath: `/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]`