### PR TITLE
Fix FieldAnimationComponent skipping last frame

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/constraints/animation/AnimationComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/constraints/animation/AnimationComponent.kt
@@ -287,8 +287,7 @@ sealed class FieldAnimationComponent<T>(
     override fun animationFrame() {
         super.animationFrame()
 
-        if (!isComplete())
-            setValue(getPercentComplete())
+        setValue(getPercentComplete())
     }
 
     abstract fun setValue(percentComplete: Float)


### PR DESCRIPTION
The FieldAnimationComponent skips the last frame, as it only sets the value when its not complete, which it is on the last frame.