### PR TITLE
ScrollComponent: Implement better specification of direction

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -363,7 +363,6 @@ public final class gg/essential/elementa/components/ScrollComponent : gg/essenti
 	public final fun getEmptyText ()Lgg/essential/elementa/components/UIWrappedText;
 	public final fun getHorizontalOffset ()F
 	public final fun getHorizontalOverhang ()F
-	public final fun getMouseScrollLambda ()Lkotlin/jvm/functions/Function2;
 	public final fun getVerticalOffset ()F
 	public final fun getVerticalOverhang ()F
 	public fun hitTest (FF)Lgg/essential/elementa/UIComponent;

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -338,8 +338,8 @@ public final class gg/essential/elementa/components/ScrollComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;F)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;)V
-	public fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZZFFLgg/essential/elementa/UIComponent;)V
-	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZZFFLgg/essential/elementa/UIComponent;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZFFLgg/essential/elementa/UIComponent;Z)V
+	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZFFLgg/essential/elementa/UIComponent;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;Z)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZ)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZ)V
@@ -347,8 +347,7 @@ public final class gg/essential/elementa/components/ScrollComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZF)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFF)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;)V
-	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;Z)V
-	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun addChild (Lgg/essential/elementa/UIComponent;)Lgg/essential/elementa/UIComponent;
 	public fun addChild (Lgg/essential/elementa/UIComponent;)Lgg/essential/elementa/components/ScrollComponent;
 	public final fun addScrollAdjustEvent (ZLkotlin/jvm/functions/Function2;)V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -5,6 +5,7 @@ public final class gg/essential/elementa/ElementaVersion : java/lang/Enum {
 	public static final field V2 Lgg/essential/elementa/ElementaVersion;
 	public static final field V3 Lgg/essential/elementa/ElementaVersion;
 	public static final field V4 Lgg/essential/elementa/ElementaVersion;
+	public static final field V5 Lgg/essential/elementa/ElementaVersion;
 	public final fun enableFor (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static fun valueOf (Ljava/lang/String;)Lgg/essential/elementa/ElementaVersion;
 	public static fun values ()[Lgg/essential/elementa/ElementaVersion;
@@ -337,6 +338,8 @@ public final class gg/essential/elementa/components/ScrollComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;F)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;)V
+	public fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZZFFLgg/essential/elementa/UIComponent;)V
+	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZZFFLgg/essential/elementa/UIComponent;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;Z)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZ)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZ)V
@@ -344,7 +347,8 @@ public final class gg/essential/elementa/components/ScrollComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZF)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFF)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;)V
-	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;Z)V
+	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun addChild (Lgg/essential/elementa/UIComponent;)Lgg/essential/elementa/UIComponent;
 	public fun addChild (Lgg/essential/elementa/UIComponent;)Lgg/essential/elementa/components/ScrollComponent;
 	public final fun addScrollAdjustEvent (ZLkotlin/jvm/functions/Function2;)V
@@ -360,6 +364,7 @@ public final class gg/essential/elementa/components/ScrollComponent : gg/essenti
 	public final fun getEmptyText ()Lgg/essential/elementa/components/UIWrappedText;
 	public final fun getHorizontalOffset ()F
 	public final fun getHorizontalOverhang ()F
+	public final fun getMouseScrollLambda ()Lkotlin/jvm/functions/Function2;
 	public final fun getVerticalOffset ()F
 	public final fun getVerticalOverhang ()F
 	public fun hitTest (FF)Lgg/essential/elementa/UIComponent;
@@ -407,6 +412,15 @@ public final class gg/essential/elementa/components/ScrollComponent$Companion {
 public final class gg/essential/elementa/components/ScrollComponent$DefaultScrollBar : gg/essential/elementa/UIComponent {
 	public fun <init> (Z)V
 	public final fun getGrip ()Lgg/essential/elementa/UIComponent;
+}
+
+public final class gg/essential/elementa/components/ScrollComponent$Direction : java/lang/Enum {
+	public static final field Horizontal Lgg/essential/elementa/components/ScrollComponent$Direction;
+	public static final field PreferHorizontal Lgg/essential/elementa/components/ScrollComponent$Direction;
+	public static final field PreferVertical Lgg/essential/elementa/components/ScrollComponent$Direction;
+	public static final field Vertical Lgg/essential/elementa/components/ScrollComponent$Direction;
+	public static fun valueOf (Ljava/lang/String;)Lgg/essential/elementa/components/ScrollComponent$Direction;
+	public static fun values ()[Lgg/essential/elementa/components/ScrollComponent$Direction;
 }
 
 public final class gg/essential/elementa/components/ScrollComponent$ScrollChildConstraint : gg/essential/elementa/constraints/HeightConstraint, gg/essential/elementa/constraints/WidthConstraint {

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -78,7 +78,13 @@ enum class ElementaVersion {
      * On prior versions, calling [gg.essential.elementa.UIComponent.enableEffect] on a component that wasn't yet initialized would result
      * in the Effect's `beforeDraw` being called once before `setup`.
      */
+    @Deprecated(DEPRECATION_MESSAGE)
     V4,
+
+    /**
+     * Change the behavior of scroll components to no longer require holding down shift when horizontal is the only possible scrolling direction.
+     */
+    V5,
 
     ;
 
@@ -118,7 +124,9 @@ Be sure to read through all the changes between your current version and your ne
         internal val v2 = V2
         @Suppress("DEPRECATION")
         internal val v3 = V3
+        @Suppress("DEPRECATION")
         internal val v4 = V4
+        internal val v5 = V5
 
 
         @PublishedApi

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -147,8 +147,8 @@ class ScrollComponent constructor(
         if (Window.of(this).version >= ElementaVersion.v5) {
             // new behavior
             val scrollDirection = if (!UKeyboard.isShiftKeyDown()) primaryScrollDirection else secondaryScrollDirection
-            scrollDirection?.let { direction ->
-                if (onScroll(it.delta.toFloat(), isHorizontal = direction == Direction.Horizontal) || !passthroughScroll) {
+            if (scrollDirection != null) {
+                if (onScroll(it.delta.toFloat(), isHorizontal = scrollDirection == Direction.Horizontal) || !passthroughScroll) {
                     it.stopPropagation()
                 }
             }

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -26,13 +26,13 @@ class ScrollComponent constructor(
     emptyString: String = "",
     private val innerPadding: Float = 0f,
     private val scrollIconColor: Color = Color.WHITE,
-    private val scrollDirection: Direction = Direction.PreferVertical,
+    private val scrollDirection: Direction,
     private val horizontalScrollOpposite: Boolean = false,
     private val verticalScrollOpposite: Boolean = false,
-    private val passthroughScroll: Boolean = true,
     private val pixelsPerScroll: Float = 15f,
     private val scrollAcceleration: Float = 1.0f,
-    customScissorBoundingBox: UIComponent? = null
+    customScissorBoundingBox: UIComponent? = null,
+    private val passthroughScroll: Boolean = true
 ) : UIContainer() {
     @JvmOverloads constructor(
         emptyString: String = "",
@@ -44,8 +44,7 @@ class ScrollComponent constructor(
         verticalScrollOpposite: Boolean = false,
         pixelsPerScroll: Float = 15f,
         scrollAcceleration: Float = 1.0f,
-        customScissorBoundingBox: UIComponent? = null,
-        passthroughScroll: Boolean = true
+        customScissorBoundingBox: UIComponent? = null
     ) : this (
         emptyString,
         innerPadding,
@@ -58,7 +57,6 @@ class ScrollComponent constructor(
         },
         horizontalScrollOpposite,
         verticalScrollOpposite,
-        passthroughScroll,
         pixelsPerScroll,
         scrollAcceleration,
         customScissorBoundingBox

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -143,7 +143,7 @@ class ScrollComponent constructor(
 
 
 
-    val mouseScrollLambda: UIComponent.(UIScrollEvent) -> Unit = {
+    private val mouseScrollLambda: UIComponent.(UIScrollEvent) -> Unit = {
         if (Window.of(this).version >= ElementaVersion.v5) {
             // new behavior
             val scrollDirection = if (!UKeyboard.isShiftKeyDown()) primaryScrollDirection else secondaryScrollDirection

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -20,7 +20,7 @@ import kotlin.math.max
  *
  * Also prevents scrolling past what should be reasonable.
  */
-class ScrollComponent @JvmOverloads constructor(
+class ScrollComponent constructor(
     emptyString: String = "",
     private val innerPadding: Float = 0f,
     private val scrollIconColor: Color = Color.WHITE,

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -150,12 +150,10 @@ class ScrollComponent constructor(
             // new behavior
             val scrollDirection = if (!UKeyboard.isShiftKeyDown()) primaryScrollDirection else secondaryScrollDirection
             scrollDirection?.let { direction ->
-                if (!onScroll(it.delta.toFloat(), isHorizontal = direction == Direction.Horizontal) && passthroughScroll) {
-                    getNextHighestScrollComponent()?.fireScrollEvent(it)
+                if (onScroll(it.delta.toFloat(), isHorizontal = direction == Direction.Horizontal) || !passthroughScroll) {
+                    it.stopPropagation()
                 }
             }
-
-            it.stopPropagation()
         } else {
             // old behavior
             if (UKeyboard.isShiftKeyDown() && horizontalScrollEnabled) {
@@ -715,16 +713,6 @@ class ScrollComponent constructor(
 
     private fun ClosedFloatingPointRange<Double>.width() = abs(this.start - this.endInclusive)
     private fun ClosedFloatingPointRange<Float>.width() = abs(this.start - this.endInclusive)
-
-    private fun getNextHighestScrollComponent(): ScrollComponent? {
-        var current: UIComponent = this.parent
-
-        while (current !is ScrollComponent && current.hasParent && current.parent != current) {
-            current = current.parent
-        }
-
-        return current as? ScrollComponent
-    }
 
     class DefaultScrollBar(isHorizontal: Boolean) : UIComponent() {
         val grip: UIComponent

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -435,10 +435,10 @@ class ScrollComponent constructor(
         var changed = false
         val offset = if (isHorizontal) ::horizontalOffset else ::verticalOffset
         val range = calculateOffsetRange(isHorizontal)
-        val newOffset = if(range.isEmpty()) innerPadding else offset.get() + delta * pixelsPerScroll * currentScrollAcceleration
-        if (newOffset in range) {
+        val newOffset = (if(range.isEmpty()) innerPadding else offset.get() + delta * pixelsPerScroll * currentScrollAcceleration).coerceIn(range)
+        if (newOffset != offset.get()) {
             changed = true
-            offset.set(newOffset.coerceIn(range))
+            offset.set(newOffset)
         }
 
         currentScrollAcceleration =

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -29,6 +29,7 @@ class ScrollComponent constructor(
     private val scrollDirection: Direction = Direction.PreferVertical,
     private val horizontalScrollOpposite: Boolean = false,
     private val verticalScrollOpposite: Boolean = false,
+    private val passthroughScroll: Boolean = true,
     private val pixelsPerScroll: Float = 15f,
     private val scrollAcceleration: Float = 1.0f,
     customScissorBoundingBox: UIComponent? = null
@@ -43,7 +44,8 @@ class ScrollComponent constructor(
         verticalScrollOpposite: Boolean = false,
         pixelsPerScroll: Float = 15f,
         scrollAcceleration: Float = 1.0f,
-        customScissorBoundingBox: UIComponent? = null
+        customScissorBoundingBox: UIComponent? = null,
+        passthroughScroll: Boolean = true
     ) : this (
         emptyString,
         innerPadding,
@@ -56,6 +58,7 @@ class ScrollComponent constructor(
         },
         horizontalScrollOpposite,
         verticalScrollOpposite,
+        passthroughScroll,
         pixelsPerScroll,
         scrollAcceleration,
         customScissorBoundingBox
@@ -147,7 +150,7 @@ class ScrollComponent constructor(
             // new behavior
             val scrollDirection = if (!UKeyboard.isShiftKeyDown()) primaryScrollDirection else secondaryScrollDirection
             scrollDirection?.let { direction ->
-                if (!onScroll(it.delta.toFloat(), isHorizontal = direction == Direction.Horizontal)) {
+                if (!onScroll(it.delta.toFloat(), isHorizontal = direction == Direction.Horizontal) && passthroughScroll) {
                     getNextHighestScrollComponent()?.fireScrollEvent(it)
                 }
             }


### PR DESCRIPTION
This should retain the original behavior where it defaults to preferring vertical when both are enabled. This also allows for not requiring holding shift when horizontal is the only scroll direction.

Closes #123