### PR TITLE
Build: Enable GitHub Actions based CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,61 @@
+name: Build & Publish
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      ORG_GRADLE_PROJECT_branch: ${{ github.head_ref || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: |
+            8
+            16
+            17
+
+      # Can't use setup-java for this because https://github.com/actions/setup-java/issues/366
+      - uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: gradle-wrapper-${{ hashFiles('**/gradle-wrapper.properties') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            **/loom-cache
+          key: gradle-caches-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle.properties', 'gradle/*.versions.toml') }}
+          restore-keys: |
+            gradle-caches-${{ hashFiles('**/*.gradle*') }}
+            gradle-caches-
+
+      - name: Setup environment
+        run: |
+          echo "ORG_GRADLE_PROJECT_BUILD_ID=$(expr ${{ github.run_number }} + 605)" >> "$GITHUB_ENV"
+          # GitHub runners are limited to 7GB of RAM, so we'll limit our Gradle Daemon process to about half of that
+          # which is enough so long as parallel task execution is limited.
+          # We also need to limit the Kotlin Compiler Daemon to its default value (which it seems to be perfectly
+          # fine with) as otherwise it inherits the Gradle Daemon's jvmargs putting us above the runner limit.
+          # We also pin the amount of workers, so it doesn't break should GitHub increase the default available vCPUs.
+          # We write these to GRADLE_USER_HOME to overrule the local "gradle.properties" of the project.
+          mkdir -p "${GRADLE_USER_HOME:=$HOME/.gradle}"
+          echo "org.gradle.jvmargs=-Xmx2G -Dkotlin.daemon.jvm.options=-Xmx512M" >> "$GRADLE_USER_HOME/gradle.properties"
+          echo "org.gradle.workers.max=2" >> "$GRADLE_USER_HOME/gradle.properties"
+
+      - name: Build
+        run: ./gradlew build --stacktrace
+
+      - name: Publish
+        run: ./gradlew publish --stacktrace
+        if: env.ORG_GRADLE_PROJECT_nexus_user != null
+        env:
+          ORG_GRADLE_PROJECT_nexus_user: ${{ secrets.NEXUS_USER }}
+          ORG_GRADLE_PROJECT_nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -59,48 +59,48 @@ modImplementation(include("gg.essential:elementa-$mcVersion-$mcPlatform:$buildNu
           <td>1.18.1</td>
           <td>fabric</td>
           <td>
-            <img alt="1.18.1-fabric" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.18.1-fabric/maven-metadata.xml">
+            <img alt="1.18.1-fabric" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.18.1-fabric/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.18.1</td>
           <td>forge</td>
           <td>
-            <img alt="1.18.1-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.18.1-forge/maven-metadata.xml">
+            <img alt="1.18.1-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.18.1-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.17.1</td>
           <td>fabric</td>
           <td>
-            <img alt="1.17.1-fabric" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.17.1-fabric/maven-metadata.xml">
+            <img alt="1.17.1-fabric" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.17.1-fabric/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.17.1</td>
           <td>forge</td>
           <td>
-            <img alt="1.17.1-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.17.1-forge/maven-metadata.xml">
+            <img alt="1.17.1-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.17.1-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.16.2</td>
           <td>forge</td>
           <td>
-            <img alt="1.16.2-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.16.2-forge/maven-metadata.xml">
+            <img alt="1.16.2-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.16.2-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.12.2</td>
           <td>forge</td>
           <td>
-            <img alt="1.12.2-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.12.2-forge/maven-metadata.xml">
+            <img alt="1.12.2-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.12.2-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.8.9</td>
           <td>forge</td>
-          <td><img alt="1.8.9-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.8.9-forge/maven-metadata.xml"></td>
+          <td><img alt="1.8.9-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/elementa-1.8.9-forge/maven-metadata.xml"></td>
         </tr>
       </tbody>
     </table>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
         maven("https://repo.essential.gg/repository/maven-public")
     }
     plugins {
-        val egtVersion = "0.2.2"
+        val egtVersion = "0.3.0"
         id("gg.essential.defaults") version egtVersion
         id("gg.essential.multi-version.root") version egtVersion
         id("gg.essential.multi-version.api-validation") version egtVersion


### PR DESCRIPTION
The action is identical to the one used for UniversalCraft except for the BUILD_ID offset.

EGT is updated to fix a memory leak issue in Loom which would otherwise consume more memory than available on the public GitHub Actions runners.

Also updates the build reference badges in the README to filter by `+` because our new GitHub Actions CI now uses the proper branch name (instead of `pull-#`) for pull request artifacts, so the current `pull` filter is insufficient.