### PR TITLE
ScrollComponent: fix wrong parenthesis

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -435,7 +435,7 @@ class ScrollComponent constructor(
         var changed = false
         val offset = if (isHorizontal) ::horizontalOffset else ::verticalOffset
         val range = calculateOffsetRange(isHorizontal)
-        val newOffset = (if(range.isEmpty()) innerPadding else offset.get() + delta * pixelsPerScroll * currentScrollAcceleration).coerceIn(range)
+        val newOffset = if(range.isEmpty()) innerPadding else (offset.get() + delta * pixelsPerScroll * currentScrollAcceleration).coerceIn(range)
         if (newOffset != offset.get()) {
             changed = true
             offset.set(newOffset)


### PR DESCRIPTION
This led to scroll components crashing due to coercing to an empty offset range.