### PR TITLE
Make roundToRealPixels round to 0 pixels on very small inputs

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/utils/extensions.kt
+++ b/src/main/kotlin/gg/essential/elementa/utils/extensions.kt
@@ -6,6 +6,7 @@ import gg.essential.universal.UResolution
 import gg.essential.universal.shader.BlendState
 import gg.essential.universal.shader.UShader
 import java.awt.Color
+import kotlin.math.abs
 import kotlin.math.round
 import kotlin.math.sign
 
@@ -14,11 +15,11 @@ fun Double.guiHint(roundDown: Boolean) = UIComponent.guiHint(this, roundDown)
 
 fun Float.roundToRealPixels(): Float {
     val factor = UResolution.scaleFactor.toFloat()
-    return round(this * factor).let { if (it == 0f && this != 0f) sign(this) else it } / factor
+    return round(this * factor).let { if (it == 0f && abs(this) > 0.001f) sign(this) else it } / factor
 }
 fun Double.roundToRealPixels(): Double {
     val factor = UResolution.scaleFactor
-    return round(this * factor).let { if (it == 0.0 && this != 0.0) sign(this) else it } / factor
+    return round(this * factor).let { if (it == 0.0 && abs(this) > 0.001) sign(this) else it } / factor
 }
 
 fun Color.withAlpha(alpha: Int) = Color(this.red, this.green, this.blue, alpha)


### PR DESCRIPTION
Issues arose when `-3.0517578E-5` was being rounded to -0.3333 pixels (scale factor 3). In the case of really small inputs (often caused by floating point imprecision) the method should output 0.