### PR TITLE
UIWrappedText: Fix incorrect font used for centering

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/UIWrappedText.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIWrappedText.kt
@@ -178,7 +178,7 @@ open class UIWrappedText @JvmOverloads constructor(
 
         lines.forEachIndexed { i, line ->
             val xOffset = if (centered) {
-                (width - line.width(textScale)) / 2f
+                (width - line.width(textScale, getFontProvider())) / 2f
             } else 0f
 
             getFontProvider().drawString(


### PR DESCRIPTION
No font was passed to `width`, as such it used the default MC font, which produces incorrect results when trying to use a font that has a different width.