### PR TITLE
UIComponent: clear stoppedTimers in animationFrame

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -752,6 +752,7 @@ abstract class UIComponent : Observable(), ReferenceHolder {
         }
 
         stoppedTimers.forEach { activeTimers.remove(it) }
+        stoppedTimers.clear()
     }
 
     open fun alwaysDrawChildren(): Boolean {


### PR DESCRIPTION
Otherwise, this Set will grow in size infinitely, potentially causing performance and memory issues.