### PR TITLE
Fix SiblingConstraint Crash: Add Size check before getting child

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/constraints/SiblingConstraint.kt
+++ b/src/main/kotlin/gg/essential/elementa/constraints/SiblingConstraint.kt
@@ -29,13 +29,19 @@ open class SiblingConstraint @JvmOverloads constructor(
         val index = component.parent.children.indexOf(component)
 
         if (alignOpposite) {
-            if (index == 0) return component.parent.getRight() - component.getWidth()
-            val sibling = component.parent.children[index - 1]
-            return getLeftmostPoint(sibling, component.parent, index) - component.getWidth() - padding
+            if (index > 0) {
+                val sibling = component.parent.children[index - 1]
+                return getLeftmostPoint(sibling, component.parent, index) - component.getWidth() - padding
+            } else {
+                return component.parent.getRight() - component.getWidth()
+            }
         } else {
-            if (index == 0) return component.parent.getLeft()
-            val sibling = component.parent.children[index - 1]
-            return getRightmostPoint(sibling, component.parent, index) + padding
+            if (index > 0) {
+                val sibling = component.parent.children[index - 1]
+                return getRightmostPoint(sibling, component.parent, index) + padding
+            } else {
+                return component.parent.getLeft()
+            }
         }
     }
 
@@ -51,13 +57,19 @@ open class SiblingConstraint @JvmOverloads constructor(
         val index = component.parent.children.indexOf(component)
 
         if (alignOpposite) {
-            if (index == 0) return component.parent.getBottom() - component.getHeight()
-            val sibling = component.parent.children[index - 1]
-            return getHighestPoint(sibling, component.parent, index) - component.getHeight() - padding
+            if (index > 0) {
+                val sibling = component.parent.children[index - 1]
+                return getHighestPoint(sibling, component.parent, index) - component.getHeight() - padding
+            } else {
+                return component.parent.getBottom() - component.getHeight()
+            }
         } else {
-            if (index == 0) return component.parent.getTop()
-            val sibling = component.parent.children[index - 1]
-            return getLowestPoint(sibling, component.parent, index) + padding
+            if (index > 0) {
+                val sibling = component.parent.children[index - 1]
+                return getLowestPoint(sibling, component.parent, index) + padding
+            } else {
+                return component.parent.getTop()
+            }
         }
     }
 


### PR DESCRIPTION
The new code checks if index - 1 is possible for the children array, and if its not return the value without it, this is better than before because before if the children's size changes quickly, in my case for a search bar only showing certain results, and sometimes it would crash, this fixes that crash.