### PR TITLE
AbstractTextInput: Hard-code isAllowedCharacter

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/input/AbstractTextInput.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/input/AbstractTextInput.kt
@@ -104,7 +104,7 @@ abstract class AbstractTextInput(
                 val operationToRedo = redoStack.pop()
                 operationToRedo.redo()
                 undoStack.push(operationToRedo)
-            } else if (platform.isAllowedInChat(typedChar)) { // Most of the ASCII characters
+            } else if (isAllowedCharacter(typedChar)) { // Most of the ASCII characters
                 commitTextAddition(typedChar.toString())
             } else if (keyCode == UKeyboard.KEY_LEFT) {
                 val holdingShift = UKeyboard.isShiftKeyDown()
@@ -976,6 +976,13 @@ abstract class AbstractTextInput(
         override fun undo() {
             addTextOperation.undo()
             removeTextOperation.undo()
+        }
+    }
+
+    private companion object {
+        // Mirroring ChatAllowedCharacters.isAllowedCharacter
+        private fun isAllowedCharacter(chr: Char): Boolean {
+            return chr.code != 167 && chr >= ' ' && chr.code != 127
         }
     }
 }

--- a/src/main/kotlin/gg/essential/elementa/impl/Platform.kt
+++ b/src/main/kotlin/gg/essential/elementa/impl/Platform.kt
@@ -9,8 +9,6 @@ interface Platform {
 
     var currentScreen: Any?
 
-    fun isAllowedInChat(char: Char): Boolean
-
     fun enableStencil()
 
     fun isCallingFromMinecraftThread(): Boolean

--- a/versions/src/main/java/gg/essential/elementa/impl/PlatformImpl.java
+++ b/versions/src/main/java/gg/essential/elementa/impl/PlatformImpl.java
@@ -3,7 +3,6 @@ package gg.essential.elementa.impl;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.shader.Framebuffer;
-import net.minecraft.util.ChatAllowedCharacters;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -37,11 +36,6 @@ public class PlatformImpl implements Platform {
     @Override
     public void setCurrentScreen(@Nullable Object screen) {
         Minecraft.getMinecraft().displayGuiScreen((GuiScreen) screen);
-    }
-
-    @Override
-    public boolean isAllowedInChat(char c) {
-        return ChatAllowedCharacters.isAllowedCharacter(c);
     }
 
     @Override


### PR DESCRIPTION
It shouldn't ever change and this way the same Elementa build continues to be compatible on 1.20.5+ where the MC method was moved to another class.