### PR TITLE
WindowScreen: Fix background being draw on top of screen

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/WindowScreen.kt
+++ b/src/main/kotlin/gg/essential/elementa/WindowScreen.kt
@@ -48,10 +48,10 @@ abstract class WindowScreen @JvmOverloads constructor(
             afterInitialization()
         }
 
-        super.onDrawScreen(matrixStack, mouseX, mouseY, partialTicks)
-
         if (drawDefaultBackground)
             super.onDrawBackground(matrixStack, 0)
+
+        super.onDrawScreen(matrixStack, mouseX, mouseY, partialTicks)
 
         // Now, we need to hook up Elementa to this GuiScreen. In practice, Elementa
         // is not constrained to being used solely inside of a GuiScreen, all the programmer


### PR DESCRIPTION
This was clearly wrong; just no one ever noticed because the vanilla content drawn by `super.onDrawScreen` (e.g. vanilla buttons) is usually empty for Elementa screens.
But now that I've seen it, I can't just keep it like that.