### PR TITLE
Build: Bump Kotlin, EGT, and Gradle

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -169,6 +169,11 @@ public final class gg/essential/elementa/UIComponent$Companion {
 	public final fun guiHint (FZ)F
 }
 
+public final class gg/essential/elementa/UIComponent$sam$i$java_util_function_Predicate$0 : java/util/function/Predicate {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final synthetic fun test (Ljava/lang/Object;)Z
+}
+
 public class gg/essential/elementa/UIConstraints : java/util/Observable {
 	public fun <init> (Lgg/essential/elementa/UIComponent;)V
 	public final fun copy ()Lgg/essential/elementa/UIConstraints;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,18 +1,26 @@
 import gg.essential.gradle.multiversion.StripReferencesTransform.Companion.registerStripReferencesAttribute
 import gg.essential.gradle.util.*
 import gg.essential.gradle.util.RelocationTransform.Companion.registerRelocationAttribute
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.6.10"
+    kotlin("jvm") version "1.9.23"
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.8.0"
-    id("org.jetbrains.dokka") version "1.6.10" apply false
+    id("org.jetbrains.dokka") version "1.9.20" apply false
     id("gg.essential.defaults")
 }
 
 kotlin.jvmToolchain {
     (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
 }
-tasks.compileKotlin.setJvmDefault("all-compatibility")
+
+tasks.withType<KotlinCompile> {
+    setJvmDefault("all-compatibility")
+    kotlinOptions {
+        languageVersion = "1.6"
+        apiVersion = "1.6"
+    }
+}
 
 val internal by configurations.creating {
     val relocated = registerRelocationAttribute("internal-relocated") {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
         maven("https://repo.essential.gg/repository/maven-public")
     }
     plugins {
-        val egtVersion = "0.3.0"
+        val egtVersion = "0.5.0"
         id("gg.essential.defaults") version egtVersion
         id("gg.essential.multi-version.root") version egtVersion
         id("gg.essential.multi-version.api-validation") version egtVersion


### PR DESCRIPTION
Also sets the Kotlin language and API version to keep compatibility with projects using older versions of Kotlin.

Bumped Dokka as I wasn't sure if using a mismatched Kotlin version would cause issues. (do we even need it anymore?)