### PR TITLE
UIWrappedText: Fix single-character strings not being rendered

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/UIWrappedText.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIWrappedText.kt
@@ -145,12 +145,6 @@ open class UIWrappedText @JvmOverloads constructor(
             return super.draw(matrixStack)
         }
 
-        if (width / textScale <= charWidth) {
-            // If we are smaller than a char, we can't physically split this string into
-            // "width" strings, so we'll prefer a no-op to an error.
-            return super.draw(matrixStack)
-        }
-
         UGraphics.enableBlend()
 
         val lines = if (trimText) {

--- a/src/main/kotlin/gg/essential/elementa/utils/text.kt
+++ b/src/main/kotlin/gg/essential/elementa/utils/text.kt
@@ -129,7 +129,7 @@ fun getStringSplitToWidth(
                     pushLine()
 
                 for (char in word.toCharArray()) {
-                    if ((currLine.toString() + char).width(textScale, fontProvider) > maxLineWidthSpace)
+                    if (currLine.isNotEmpty() && (currLine.toString() + char).width(textScale, fontProvider) > maxLineWidthSpace)
                         pushLine()
                     currLine.append(char)
                 }


### PR DESCRIPTION
By default, UIWrappedText will set its width to the width of the text string. When it is rendering the text, it'll check if the width of the component is less than or equal to the width of a character (in this case 'x'), this is flawed for a few reasons:
1. Different characters have different widths
2. The comment "if we are smaller than a character" doesn't match up with the behavior (less than or equal to)
3. `UGraphics.getCharWidth` (used to get the width of 'x') does not take the `fontProvider` into account, meaning that the width that it calculates for that character could be wrong.

To solve this, the check has been removed, as it is flawed and doesn't seem to have an explicit error, contrary to what the comment in the code said.

The only problem found with this was that `getStringSplitToWidth` would push an extra line onto the list if the container wasn't long enough to render one character. This has been fixed by adding a `isNotEmpty` check before pushing the line (that's okay to do in this case, as it's not a newline check).

The only "breaking change" about this, is that if your container is less than "a character" wide, they will still render. If you for some reason want to avoid this, put a `ScissorEffect` onto your `UIWrappedText`, but this shouldn't really be necessary.