### PR TITLE
UIText: Check if the textWidth is 0 instead of if the string is empty

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/UIText.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIText.kt
@@ -96,13 +96,18 @@ constructor(
     }
 
     override fun draw(matrixStack: UMatrixStack) {
-        val text = textState.get()
-        if (text.isEmpty())
+        val textWidth = textWidthState.get()
+
+        // If you're wondering why we check if the text's width is 0 instead of if the string is empty:
+        // It's better to check the width derived from the font provider, as the string may just be full of characters
+        // that can't be rendered (as they aren't supported by current font).
+        // This check prevents issues from occurring later, e.g. when calculating the scale of the text.
+        if (textWidth == 0f)
             return
 
         beforeDrawCompat(matrixStack)
 
-        val scale = getWidth() / textWidthState.get()
+        val scale = getWidth() / textWidth
         val x = getLeft()
         val y = getTop() + (if (verticallyCenteredState.get()) fontProviderState.get().getBelowLineHeight() * scale else 0f)
         val color = getColor()


### PR DESCRIPTION
This fixes an issue on certain versions of Minecraft where the vanilla font provider returns a width of 0 for unsupported characters. This caused the scale to be calculated incorrectly later on, which completely broke rendering.