### PR TITLE
Window: Call `super.afterInitialization`

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/Window.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/Window.kt
@@ -46,6 +46,8 @@ class Window @JvmOverloads constructor(
     }
 
     override fun afterInitialization() {
+        super.afterInitialization()
+
         enqueueRenderOperation {
             FontRenderer.initShaders()
             UICircle.initShaders()


### PR DESCRIPTION
This allows effects to be setup correctly if placed on a `Window`.