### PR TITLE
Fix library being incorrectly declared as a `LIBRARY`

### DIFF
--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -84,7 +84,9 @@ tasks.jar {
     exclude("mcmod.info")
     exclude("kotlin/**")
     manifest {
-        attributes(mapOf("FMLModType" to "LIBRARY"))
+        if (platform.isModLauncher) {
+            attributes(mapOf("FMLModType" to "GAMELIBRARY"))
+        }
     }
 }
 

--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -83,11 +83,6 @@ tasks.jar {
     exclude("META-INF/mods.toml")
     exclude("mcmod.info")
     exclude("kotlin/**")
-    manifest {
-        if (platform.isModLauncher) {
-            attributes(mapOf("FMLModType" to "GAMELIBRARY"))
-        }
-    }
 }
 
 tasks.named<Jar>("sourcesJar") {


### PR DESCRIPTION
See [UniversalCraft#73](https://github.com/EssentialGG/UniversalCraft/pull/73)