### PR TITLE
ScrollComponent: Add a minimum scrollbar grip size

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -343,8 +343,8 @@ public final class gg/essential/elementa/components/ScrollComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;F)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;)V
-	public fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZFFLgg/essential/elementa/UIComponent;Z)V
-	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZFFLgg/essential/elementa/UIComponent;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZFFLgg/essential/elementa/UIComponent;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZFFLgg/essential/elementa/UIComponent;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;Z)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZ)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZ)V
@@ -352,7 +352,9 @@ public final class gg/essential/elementa/components/ScrollComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZF)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFF)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;)V
-	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;Z)V
+	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun addChild (Lgg/essential/elementa/UIComponent;)Lgg/essential/elementa/UIComponent;
 	public fun addChild (Lgg/essential/elementa/UIComponent;)Lgg/essential/elementa/components/ScrollComponent;
 	public final fun addScrollAdjustEvent (ZLkotlin/jvm/functions/Function2;)V
@@ -424,6 +426,20 @@ public final class gg/essential/elementa/components/ScrollComponent$Direction : 
 	public static final field Vertical Lgg/essential/elementa/components/ScrollComponent$Direction;
 	public static fun valueOf (Ljava/lang/String;)Lgg/essential/elementa/components/ScrollComponent$Direction;
 	public static fun values ()[Lgg/essential/elementa/components/ScrollComponent$Direction;
+}
+
+public final class gg/essential/elementa/components/ScrollComponent$ScrollBarGripMinHeightConstraint : gg/essential/elementa/constraints/HeightConstraint {
+	public fun <init> (Lgg/essential/elementa/components/ScrollComponent;Lgg/essential/elementa/constraints/HeightConstraint;)V
+	public fun getCachedValue ()Ljava/lang/Float;
+	public synthetic fun getCachedValue ()Ljava/lang/Object;
+	public fun getConstrainTo ()Lgg/essential/elementa/UIComponent;
+	public fun getHeightImpl (Lgg/essential/elementa/UIComponent;)F
+	public fun getRecalculate ()Z
+	public fun setCachedValue (F)V
+	public synthetic fun setCachedValue (Ljava/lang/Object;)V
+	public fun setConstrainTo (Lgg/essential/elementa/UIComponent;)V
+	public fun setRecalculate (Z)V
+	public fun visitImpl (Lgg/essential/elementa/constraints/resolution/ConstraintVisitor;Lgg/essential/elementa/constraints/ConstraintType;)V
 }
 
 public final class gg/essential/elementa/components/ScrollComponent$ScrollChildConstraint : gg/essential/elementa/constraints/HeightConstraint, gg/essential/elementa/constraints/WidthConstraint {

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -427,13 +427,16 @@ public final class gg/essential/elementa/components/ScrollComponent$Direction : 
 	public static fun values ()[Lgg/essential/elementa/components/ScrollComponent$Direction;
 }
 
-public final class gg/essential/elementa/components/ScrollComponent$ScrollBarGripMinHeightConstraint : gg/essential/elementa/constraints/HeightConstraint {
-	public fun <init> (Lgg/essential/elementa/components/ScrollComponent;Lgg/essential/elementa/constraints/HeightConstraint;)V
+public final class gg/essential/elementa/components/ScrollComponent$ScrollBarGripMinSizeConstraint : gg/essential/elementa/constraints/SizeConstraint {
+	public fun <init> (Lgg/essential/elementa/components/ScrollComponent;Lgg/essential/elementa/constraints/SizeConstraint;)V
+	public fun animationFrame ()V
 	public fun getCachedValue ()Ljava/lang/Float;
 	public synthetic fun getCachedValue ()Ljava/lang/Object;
 	public fun getConstrainTo ()Lgg/essential/elementa/UIComponent;
 	public fun getHeightImpl (Lgg/essential/elementa/UIComponent;)F
+	public fun getRadiusImpl (Lgg/essential/elementa/UIComponent;)F
 	public fun getRecalculate ()Z
+	public fun getWidthImpl (Lgg/essential/elementa/UIComponent;)F
 	public fun setCachedValue (F)V
 	public synthetic fun setCachedValue (Ljava/lang/Object;)V
 	public fun setConstrainTo (Lgg/essential/elementa/UIComponent;)V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -427,23 +427,6 @@ public final class gg/essential/elementa/components/ScrollComponent$Direction : 
 	public static fun values ()[Lgg/essential/elementa/components/ScrollComponent$Direction;
 }
 
-public final class gg/essential/elementa/components/ScrollComponent$ScrollBarGripMinSizeConstraint : gg/essential/elementa/constraints/SizeConstraint {
-	public fun <init> (Lgg/essential/elementa/components/ScrollComponent;Lgg/essential/elementa/constraints/SizeConstraint;)V
-	public fun animationFrame ()V
-	public fun getCachedValue ()Ljava/lang/Float;
-	public synthetic fun getCachedValue ()Ljava/lang/Object;
-	public fun getConstrainTo ()Lgg/essential/elementa/UIComponent;
-	public fun getHeightImpl (Lgg/essential/elementa/UIComponent;)F
-	public fun getRadiusImpl (Lgg/essential/elementa/UIComponent;)F
-	public fun getRecalculate ()Z
-	public fun getWidthImpl (Lgg/essential/elementa/UIComponent;)F
-	public fun setCachedValue (F)V
-	public synthetic fun setCachedValue (Ljava/lang/Object;)V
-	public fun setConstrainTo (Lgg/essential/elementa/UIComponent;)V
-	public fun setRecalculate (Z)V
-	public fun visitImpl (Lgg/essential/elementa/constraints/resolution/ConstraintVisitor;Lgg/essential/elementa/constraints/ConstraintType;)V
-}
-
 public final class gg/essential/elementa/components/ScrollComponent$ScrollChildConstraint : gg/essential/elementa/constraints/HeightConstraint, gg/essential/elementa/constraints/WidthConstraint {
 	public fun <init> (Lgg/essential/elementa/components/ScrollComponent;F)V
 	public synthetic fun <init> (Lgg/essential/elementa/components/ScrollComponent;FILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -6,6 +6,7 @@ public final class gg/essential/elementa/ElementaVersion : java/lang/Enum {
 	public static final field V3 Lgg/essential/elementa/ElementaVersion;
 	public static final field V4 Lgg/essential/elementa/ElementaVersion;
 	public static final field V5 Lgg/essential/elementa/ElementaVersion;
+	public static final field V6 Lgg/essential/elementa/ElementaVersion;
 	public final fun enableFor (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static fun valueOf (Ljava/lang/String;)Lgg/essential/elementa/ElementaVersion;
 	public static fun values ()[Lgg/essential/elementa/ElementaVersion;
@@ -343,8 +344,8 @@ public final class gg/essential/elementa/components/ScrollComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;F)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;)V
-	public fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZFFLgg/essential/elementa/UIComponent;ZZ)V
-	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZFFLgg/essential/elementa/UIComponent;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZFFLgg/essential/elementa/UIComponent;Z)V
+	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;Lgg/essential/elementa/components/ScrollComponent$Direction;ZZFFLgg/essential/elementa/UIComponent;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;Z)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZ)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZ)V
@@ -352,9 +353,7 @@ public final class gg/essential/elementa/components/ScrollComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZF)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFF)V
 	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;)V
-	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;Z)V
-	public fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;ZZ)V
-	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;FLjava/awt/Color;ZZZZFFLgg/essential/elementa/UIComponent;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun addChild (Lgg/essential/elementa/UIComponent;)Lgg/essential/elementa/UIComponent;
 	public fun addChild (Lgg/essential/elementa/UIComponent;)Lgg/essential/elementa/components/ScrollComponent;
 	public final fun addScrollAdjustEvent (ZLkotlin/jvm/functions/Function2;)V

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -88,7 +88,7 @@ enum class ElementaVersion {
     V5,
 
     /**
-     * [gg.essential.elementa.components.ScrollComponent] now has a minimum height for scrollbar grips.
+     * [gg.essential.elementa.components.ScrollComponent] now has a minimum size for scrollbar grips.
      */
     V6,
 

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -84,7 +84,13 @@ enum class ElementaVersion {
     /**
      * Change the behavior of scroll components to no longer require holding down shift when horizontal is the only possible scrolling direction.
      */
+    @Deprecated(DEPRECATION_MESSAGE)
     V5,
+
+    /**
+     * [gg.essential.elementa.components.ScrollComponent] now has a minimum height for scrollbar grips.
+     */
+    V6,
 
     ;
 
@@ -126,7 +132,9 @@ Be sure to read through all the changes between your current version and your ne
         internal val v3 = V3
         @Suppress("DEPRECATION")
         internal val v4 = V4
+        @Suppress("DEPRECATION")
         internal val v5 = V5
+        internal val v6 = V6
 
 
         @PublishedApi

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -33,7 +33,6 @@ class ScrollComponent constructor(
     private val scrollAcceleration: Float = 1.0f,
     customScissorBoundingBox: UIComponent? = null,
     private val passthroughScroll: Boolean = true,
-    private val limitScrollBarGripHeight: Boolean = false,
 ) : UIContainer() {
     @JvmOverloads constructor(
         emptyString: String = "",
@@ -46,8 +45,6 @@ class ScrollComponent constructor(
         pixelsPerScroll: Float = 15f,
         scrollAcceleration: Float = 1.0f,
         customScissorBoundingBox: UIComponent? = null,
-        passthroughScroll: Boolean = true,
-        limitScrollBarGripHeight: Boolean = false,
     ) : this (
         emptyString,
         innerPadding,
@@ -63,8 +60,6 @@ class ScrollComponent constructor(
         pixelsPerScroll,
         scrollAcceleration,
         customScissorBoundingBox,
-        passthroughScroll,
-        limitScrollBarGripHeight,
     )
 
     private val primaryScrollDirection
@@ -475,7 +470,12 @@ class ScrollComponent constructor(
             component.setWidth(RelativeConstraint(clampedPercentage))
         } else {
             val heightConstraint = RelativeConstraint(clampedPercentage)
-            component.setHeight(if (limitScrollBarGripHeight) ScrollBarGripMinHeightConstraint(heightConstraint) else heightConstraint)
+
+            if (Window.of(this).version >= ElementaVersion.v6) {
+                component.setHeight(ScrollBarGripMinHeightConstraint(heightConstraint))
+            } else {
+                component.setHeight(heightConstraint)
+            }
         }
 
         component.animate {
@@ -808,7 +808,7 @@ class ScrollComponent constructor(
 
     /**
      * Constraints the scrollbar grip's height to be a certain minimum height, or the [desiredHeight].
-     * This is the default constraint for vertical scrollbar grips if [limitScrollBarGripHeight] is enabled.
+     * This is the default constraint for vertical scrollbar grips if [ElementaVersion.V6] is used.
      *
      * @param desiredHeight The intended height for the scrollbar grip.
      */

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -819,6 +819,11 @@ class ScrollComponent constructor(
         override var recalculate: Boolean = true
         override var constrainTo: UIComponent? = null
 
+        override fun animationFrame() {
+            super.animationFrame()
+            desiredHeight.animationFrame()
+        }
+
         override fun getHeightImpl(component: UIComponent): Float {
             val parent = component.parent
             val minimumHeight = if (parent.getHeight() < 200) { 15.percent } else { 10.percent }

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -826,8 +826,10 @@ class ScrollComponent constructor(
 
         override fun getHeightImpl(component: UIComponent): Float {
             val parent = component.parent
-            val minimumHeight = if (parent.getHeight() < 200) { 15.percent } else { 10.percent }
-            return desiredHeight.coerceAtLeast(minimumHeight).getHeight(component)
+            val minimumHeightPercentage = if (parent.getHeight() < 200) { 0.15f } else { 0.10f }
+            val minimumHeight = parent.getHeight() * minimumHeightPercentage
+
+            return desiredHeight.getHeight(component).coerceAtLeast(minimumHeight)
         }
 
         override fun visitImpl(visitor: ConstraintVisitor, type: ConstraintType) {

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -813,7 +813,7 @@ class ScrollComponent constructor(
      *
      * @param desiredSize The intended size for the scrollbar grip.
      */
-    inner class ScrollBarGripMinSizeConstraint(
+    private class ScrollBarGripMinSizeConstraint(
         private val desiredSize: SizeConstraint
     ) : SizeConstraint {
         override var cachedValue: Float = 0f

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -831,7 +831,6 @@ class ScrollComponent constructor(
         }
 
         override fun visitImpl(visitor: ConstraintVisitor, type: ConstraintType) {
-            if (type == ConstraintType.HEIGHT) visitor.visitChildren(type)
         }
     }
 


### PR DESCRIPTION
This will ensure that the vertical scroll bar grip is at least a minimum height, making it easier to grab when there is a lot of content within the ScrollComponent.