### PR TITLE
Build: Publish sources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,8 @@ apiValidation {
     nonPublicMarkers.add("org.jetbrains.annotations.ApiStatus\$Internal")
 }
 
+java.withSourcesJar()
+
 publishing.publications.named<MavenPublication>("maven") {
     artifactId = "elementa"
 }

--- a/unstable/layoutdsl/build.gradle.kts
+++ b/unstable/layoutdsl/build.gradle.kts
@@ -28,6 +28,8 @@ kotlin.jvmToolchain {
     (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
 }
 
+java.withSourcesJar()
+
 publishing {
     publications {
         named<MavenPublication>("maven") {

--- a/unstable/statev2/build.gradle.kts
+++ b/unstable/statev2/build.gradle.kts
@@ -28,6 +28,8 @@ kotlin.jvmToolchain {
     (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
 }
 
+java.withSourcesJar()
+
 publishing {
     publications {
         named<MavenPublication>("maven") {


### PR DESCRIPTION
We used to publish these for the main Elementa artifact but accidentially stopped doing so with 0b76fa7c.

For the unstable artifacts we had never published them.