### PR TITLE
Inspector: Show source file of components and jump there in IntelliJ

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -1158,6 +1158,8 @@ public final class gg/essential/elementa/components/inspector/Inspector : gg/ess
 }
 
 public final class gg/essential/elementa/components/inspector/Inspector$Companion {
+	public final fun registerComponentFactory (Ljava/lang/Class;Ljava/lang/String;)V
+	public static synthetic fun registerComponentFactory$default (Lgg/essential/elementa/components/inspector/Inspector$Companion;Ljava/lang/Class;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public final class gg/essential/elementa/components/inspector/InspectorNode : gg/essential/elementa/components/TreeNode {

--- a/src/main/kotlin/gg/essential/elementa/components/UIImage.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIImage.kt
@@ -2,6 +2,7 @@ package gg.essential.elementa.components
 
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.components.image.*
+import gg.essential.elementa.components.inspector.Inspector
 import gg.essential.elementa.utils.ResourceCache
 import gg.essential.elementa.utils.drawTexture
 import gg.essential.universal.UGraphics
@@ -126,6 +127,10 @@ open class UIImage @JvmOverloads constructor(
     companion object {
 
         val defaultResourceCache = ResourceCache(50)
+
+        init {
+            Inspector.registerComponentFactory(Companion::class.java)
+        }
 
         @JvmStatic
         fun ofFile(file: File): UIImage {

--- a/src/main/kotlin/gg/essential/elementa/components/inspector/InspectorNode.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/inspector/InspectorNode.kt
@@ -11,31 +11,35 @@ import gg.essential.elementa.dsl.toConstraint
 import gg.essential.elementa.dsl.childOf
 import gg.essential.elementa.dsl.constrain
 import gg.essential.elementa.dsl.pixels
+import gg.essential.universal.UKeyboard
+import gg.essential.universal.UMatrixStack
 import java.awt.Color
 
 class InspectorNode(private val inspector: Inspector, val targetComponent: UIComponent) : TreeNode() {
     private val componentClassName = targetComponent.javaClass.simpleName.ifEmpty { "UnknownType" }
     private val componentDisplayName = targetComponent.componentName.let { if (it == componentClassName) it else "$componentClassName: $it" }
-    private var wasHidden = false
+
+    private var selectedSource = targetComponent.primarySource
+    internal var selectedSourceIndex: Int = targetComponent.filteredSource?.indexOf(selectedSource) ?: 0
+        set(value) {
+            field = value
+            selectedSource = targetComponent.filteredSource?.get(value)
+        }
 
     private val component: UIComponent = object : UIBlock(Color(0, 0, 0, 0)) {
         private val text = UIText(componentDisplayName).constrain {
             width = TextAspectConstraint()
         } childOf this
 
-        override fun animationFrame() {
-            super.animationFrame()
-
+        override fun draw(matrixStack: UMatrixStack) {
             val isCurrentlyHidden = targetComponent.parent != targetComponent && !targetComponent.parent.children.contains(
                 targetComponent
             )
-            if (isCurrentlyHidden && !wasHidden) {
-                wasHidden = true
-                text.setText("§r$componentDisplayName §7§o(Hidden)")
-            } else if (!isCurrentlyHidden && wasHidden) {
-                wasHidden = false
-                text.setText(componentDisplayName)
-            }
+            val file = selectedSource?.let { " §7${it.fileName ?: it.className.substringAfterLast(".")}:${it.lineNumber}" } ?: ""
+            val hidden = if (isCurrentlyHidden) " §7§o(Hidden)" else ""
+            text.setText("§r$componentDisplayName$file$hidden")
+
+            super.draw(matrixStack)
         }
     }.constrain {
         x = SiblingConstraint()
@@ -45,6 +49,10 @@ class InspectorNode(private val inspector: Inspector, val targetComponent: UICom
     }.onMouseClick { event ->
         event.stopImmediatePropagation()
         toggleSelection()
+    }.onMouseScroll { event ->
+        if (!UKeyboard.isShiftKeyDown()) return@onMouseScroll
+        event.stopImmediatePropagation()
+        inspector.scrollSource(this@InspectorNode, event.delta > 0)
     }
 
     internal fun toggleSelection() {

--- a/src/main/kotlin/gg/essential/elementa/components/inspector/InspectorNode.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/inspector/InspectorNode.kt
@@ -32,14 +32,14 @@ class InspectorNode(private val inspector: Inspector, val targetComponent: UICom
         } childOf this
 
         override fun draw(matrixStack: UMatrixStack) {
+            super.draw(matrixStack)
+
             val isCurrentlyHidden = targetComponent.parent != targetComponent && !targetComponent.parent.children.contains(
                 targetComponent
             )
             val file = selectedSource?.let { " §7${it.fileName ?: it.className.substringAfterLast(".")}:${it.lineNumber}" } ?: ""
             val hidden = if (isCurrentlyHidden) " §7§o(Hidden)" else ""
             text.setText("§r$componentDisplayName$file$hidden")
-
-            super.draw(matrixStack)
         }
     }.constrain {
         x = SiblingConstraint()

--- a/src/main/kotlin/gg/essential/elementa/utils/ResourceCache.kt
+++ b/src/main/kotlin/gg/essential/elementa/utils/ResourceCache.kt
@@ -3,6 +3,7 @@ package gg.essential.elementa.utils
 import gg.essential.elementa.components.UIImage
 import gg.essential.elementa.components.image.CacheableImage
 import gg.essential.elementa.components.image.MSDFComponent
+import gg.essential.elementa.components.inspector.Inspector
 import java.awt.image.BufferedImage
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
@@ -42,6 +43,12 @@ class ResourceCache(val size: Int = 50) {
         }
         return MSDFComponent(CompletableFuture.completedFuture<BufferedImage>(null)).also {
             cachedImage.supply(it)
+        }
+    }
+
+    private companion object {
+        init {
+            Inspector.registerComponentFactory(ResourceCache::class.java)
         }
     }
 }


### PR DESCRIPTION
This commit tries to track the source code location of components (not where its class is defined but where that particular instance was created) and shows that info in the inspector. Should the automatically determined location be unhelpful (e.g. because it's in a factory function rather than where the factory function is called), then it also allows scrolling while holding the Shift key to go up and down the call stack.

If IntelliJ is running, it will also automatically jump to that source location every time a component is selected in the inspector.

![](https://i.johni0702.de/CO2Qv.png)