### PR TITLE
GradientComponent: Fix blending not being enabled

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/GradientComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/GradientComponent.kt
@@ -149,6 +149,7 @@ open class GradientComponent constructor(
             startColor: Color, endColor: Color, direction: GradientDirection
         ) {
             UGraphics.disableAlpha()
+            UGraphics.enableBlend()
             UGraphics.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO)
             UGraphics.shadeModel(GL11.GL_SMOOTH)
 


### PR DESCRIPTION
This call was accidentally dropped in https://github.com/EssentialGG/Elementa/commit/f9c95e800c8e19187b4ee663117e0c5cf48f9651#diff-bc7125e63fa8e1fe130c0591fecb4078dad770ace6f613ec4ce3cb9729c8ee98L126, breaking translucent GradientComponents on versions prior to 1.21.5 unless blending happens to already be enabled.

UIText always enables blending but does not disable it (MC's font renderer itself only disables it on more modern versions, not sure where the cut-off is but 1.12.2 still leaves it enabled), and one of out two remaining GradientComponent we use in Essential (we've mostly switched to GradientEffect) is on top of text, hence why this wasn't noticed immediately.

Linear: EM-3177