### PR TITLE
Use BlendState.ALPHA across all components

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -9,6 +9,7 @@ public final class gg/essential/elementa/ElementaVersion : java/lang/Enum {
 	public static final field V6 Lgg/essential/elementa/ElementaVersion;
 	public static final field V7 Lgg/essential/elementa/ElementaVersion;
 	public static final field V8 Lgg/essential/elementa/ElementaVersion;
+	public static final field V9 Lgg/essential/elementa/ElementaVersion;
 	public final fun enableFor (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static fun valueOf (Ljava/lang/String;)Lgg/essential/elementa/ElementaVersion;
 	public static fun values ()[Lgg/essential/elementa/ElementaVersion;

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -2,6 +2,7 @@ public final class gg/essential/elementa/ElementaVersion : java/lang/Enum {
 	public static final field Companion Lgg/essential/elementa/ElementaVersion$Companion;
 	public static final field V0 Lgg/essential/elementa/ElementaVersion;
 	public static final field V1 Lgg/essential/elementa/ElementaVersion;
+	public static final field V10 Lgg/essential/elementa/ElementaVersion;
 	public static final field V2 Lgg/essential/elementa/ElementaVersion;
 	public static final field V3 Lgg/essential/elementa/ElementaVersion;
 	public static final field V4 Lgg/essential/elementa/ElementaVersion;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "1.5.10"
 kotlinx-coroutines = "1.5.2"
 jetbrains-annotations = "23.0.0"
-universalcraft = "389"
+universalcraft = "406"
 commonmark = "0.17.1"
 dom4j = "2.1.1"
 

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -1,10 +1,13 @@
 package gg.essential.elementa
 
+import gg.essential.elementa.components.UIText
+import gg.essential.elementa.components.UIWrappedText
 import gg.essential.elementa.components.UpdateFunc
 import gg.essential.elementa.components.Window
 import gg.essential.elementa.constraints.SuperConstraint
 import gg.essential.elementa.constraints.animation.AnimationComponent
 import gg.essential.elementa.effects.Effect
+import gg.essential.universal.render.URenderPipeline
 
 /**
  * Sometimes it is necessary or desirable to introduce breaking behavioral changes to Elementa. In order to maintain
@@ -170,7 +173,14 @@ enum class ElementaVersion {
      *   The new constraint tracking will only invalidate constraints which were evaluated, and the [UpdateFunc]s
      *   are tracked intelligently at registration, such that no more full tree traversals should be necessary.
      */
+    @Deprecated(DEPRECATION_MESSAGE)
     V8,
+
+    /**
+     * All Minecraft versions now use [URenderPipeline] instead of modifying global GL state.
+     * Additionally, [UIText] and [UIWrappedText] no longer enable (and forget to disable) blending.
+     */
+    V9,
 
     ;
 
@@ -218,8 +228,12 @@ Be sure to read through all the changes between your current version and your ne
         internal val v6 = V6
         @Suppress("DEPRECATION")
         internal val v7 = V7
+        @Suppress("DEPRECATION")
         internal val v8 = V8
+        internal val v9 = V9
 
+        internal val atLeastV9Active: Boolean
+            get() = active >= v9
 
         @PublishedApi
         internal var active: ElementaVersion = v0

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -8,6 +8,7 @@ import gg.essential.elementa.constraints.SuperConstraint
 import gg.essential.elementa.constraints.animation.AnimationComponent
 import gg.essential.elementa.effects.Effect
 import gg.essential.universal.render.URenderPipeline
+import gg.essential.universal.shader.BlendState
 
 /**
  * Sometimes it is necessary or desirable to introduce breaking behavioral changes to Elementa. In order to maintain
@@ -180,7 +181,15 @@ enum class ElementaVersion {
      * All Minecraft versions now use [URenderPipeline] instead of modifying global GL state.
      * Additionally, [UIText] and [UIWrappedText] no longer enable (and forget to disable) blending.
      */
+    @Deprecated(DEPRECATION_MESSAGE)
     V9,
+
+    /**
+     * All components now use [BlendState.ALPHA] instead of [BlendState.NORMAL] and variants.
+     * This fixes the alpha channel of the render result, allowing it to be correctly composited with other textures.
+     * See [UniversalCraft#105](https://github.com/EssentialGG/UniversalCraft/pull/105) for more details.
+     */
+    V10,
 
     ;
 
@@ -230,10 +239,14 @@ Be sure to read through all the changes between your current version and your ne
         internal val v7 = V7
         @Suppress("DEPRECATION")
         internal val v8 = V8
+        @Suppress("DEPRECATION")
         internal val v9 = V9
+        internal val v10 = V10
 
         internal val atLeastV9Active: Boolean
             get() = active >= v9
+        internal val atLeastV10Active: Boolean
+            get() = active >= v10
 
         @PublishedApi
         internal var active: ElementaVersion = v0

--- a/src/main/kotlin/gg/essential/elementa/components/GradientComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/GradientComponent.kt
@@ -1,5 +1,6 @@
 package gg.essential.elementa.components
 
+import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.state.BasicState
 import gg.essential.elementa.state.MappedState
 import gg.essential.elementa.state.State
@@ -127,7 +128,7 @@ open class GradientComponent constructor(
             endColor: Color,
             direction: GradientDirection
         ) {
-            if (!URenderPipeline.isRequired) {
+            if (!URenderPipeline.isRequired && !ElementaVersion.atLeastV9Active) {
                 @Suppress("DEPRECATION")
                 return drawGradientBlockLegacy(matrixStack, x1, y1, x2, y2, startColor, endColor, direction)
             }

--- a/src/main/kotlin/gg/essential/elementa/components/GradientComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/GradientComponent.kt
@@ -139,7 +139,7 @@ open class GradientComponent constructor(
             bufferBuilder.pos(matrixStack, x1, y1, 0.0).color(colors.topLeft).endVertex()
             bufferBuilder.pos(matrixStack, x1, y2, 0.0).color(colors.bottomLeft).endVertex()
             bufferBuilder.pos(matrixStack, x2, y2, 0.0).color(colors.bottomRight).endVertex()
-            bufferBuilder.build()?.drawAndClose(PIPELINE)
+            bufferBuilder.build()?.drawAndClose(if (ElementaVersion.atLeastV10Active) PIPELINE2 else PIPELINE)
         }
 
         @Deprecated("Stops working in 1.21.5")
@@ -169,7 +169,12 @@ open class GradientComponent constructor(
         }
 
         private val PIPELINE = URenderPipeline.builderWithDefaultShader("elementa:gradient_block", UGraphics.DrawMode.QUADS, UGraphics.CommonVertexFormats.POSITION_COLOR).apply {
+            @Suppress("DEPRECATION")
             blendState = BlendState.NORMAL.copy(srcAlpha = BlendState.Param.ONE, dstAlpha = BlendState.Param.ZERO)
+        }.build()
+
+        private val PIPELINE2 = URenderPipeline.builderWithDefaultShader("elementa:gradient_block", UGraphics.DrawMode.QUADS, UGraphics.CommonVertexFormats.POSITION_COLOR).apply {
+            blendState = BlendState.ALPHA
         }.build()
     }
 }

--- a/src/main/kotlin/gg/essential/elementa/components/UIBlock.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIBlock.kt
@@ -57,7 +57,7 @@ open class UIBlock(colorConstraint: ColorConstraint = Color.WHITE.toConstraint()
             drawBlock(UMatrixStack(), color, x1, y1, x2, y2)
 
         fun drawBlock(matrixStack: UMatrixStack, color: Color, x1: Double, y1: Double, x2: Double, y2: Double) {
-            if (!URenderPipeline.isRequired) {
+            if (!URenderPipeline.isRequired && !ElementaVersion.atLeastV9Active) {
                 @Suppress("DEPRECATION")
                 return drawBlockLegacy(matrixStack, color, x1, y1, x2, y2)
             }

--- a/src/main/kotlin/gg/essential/elementa/components/UICircle.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UICircle.kt
@@ -78,7 +78,19 @@ class UICircle @JvmOverloads constructor(radius: Float = 0f, color: Color = Colo
             readElementaShaderSource("rect", "vsh"),
             readElementaShaderSource("circle", "fsh"),
         ).apply {
+            @Suppress("DEPRECATION")
             blendState = BlendState.NORMAL
+            depthTest = URenderPipeline.DepthTest.Always // see UIBlock.PIPELINE
+        }.build()
+
+        private val PIPELINE2 = URenderPipeline.builderWithLegacyShader(
+            "elementa:circle",
+            UGraphics.DrawMode.QUADS,
+            UGraphics.CommonVertexFormats.POSITION_COLOR,
+            readElementaShaderSource("rect", "vsh"),
+            readElementaShaderSource("circle", "fsh"),
+        ).apply {
+            blendState = BlendState.ALPHA
             depthTest = URenderPipeline.DepthTest.Always // see UIBlock.PIPELINE
         }.build()
 
@@ -120,7 +132,7 @@ class UICircle @JvmOverloads constructor(radius: Float = 0f, color: Color = Colo
                 (centerX + radius).toDouble(),
                 (centerY + radius).toDouble()
             )
-            bufferBuilder.build()?.drawAndClose(PIPELINE) {
+            bufferBuilder.build()?.drawAndClose(if (ElementaVersion.atLeastV10Active) PIPELINE2 else PIPELINE) {
                 uniform("u_Radius", radius)
                 uniform("u_CenterPos", centerX, centerY)
             }

--- a/src/main/kotlin/gg/essential/elementa/components/UICircle.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UICircle.kt
@@ -1,5 +1,6 @@
 package gg.essential.elementa.components
 
+import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.dsl.toConstraint
 import gg.essential.elementa.dsl.pixels
@@ -104,7 +105,7 @@ class UICircle @JvmOverloads constructor(radius: Float = 0f, color: Color = Colo
             drawCircle(UMatrixStack(), centerX, centerY, radius, color)
 
         fun drawCircle(matrixStack: UMatrixStack, centerX: Float, centerY: Float, radius: Float, color: Color) {
-            if (!URenderPipeline.isRequired) {
+            if (!URenderPipeline.isRequired && !ElementaVersion.atLeastV9Active) {
                 @Suppress("DEPRECATION")
                 return drawCircleLegacy(matrixStack, centerX, centerY, radius, color)
             }

--- a/src/main/kotlin/gg/essential/elementa/components/UIRoundedRectangle.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIRoundedRectangle.kt
@@ -1,5 +1,6 @@
 package gg.essential.elementa.components
 
+import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.dsl.pixels
 import gg.essential.elementa.utils.readElementaShaderSource
@@ -78,7 +79,7 @@ open class UIRoundedRectangle(radius: Float) : UIComponent() {
          * Draws a rounded rectangle
          */
         fun drawRoundedRectangle(matrixStack: UMatrixStack, left: Float, top: Float, right: Float, bottom: Float, radius: Float, color: Color) {
-            if (!URenderPipeline.isRequired) {
+            if (!URenderPipeline.isRequired && !ElementaVersion.atLeastV9Active) {
                 @Suppress("DEPRECATION")
                 return drawRoundedRectangleLegacy(matrixStack, left, top, right, bottom, radius, color)
             }

--- a/src/main/kotlin/gg/essential/elementa/components/UIRoundedRectangle.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIRoundedRectangle.kt
@@ -49,7 +49,19 @@ open class UIRoundedRectangle(radius: Float) : UIComponent() {
             readElementaShaderSource("rect", "vsh"),
             readElementaShaderSource("rounded_rect", "fsh"),
         ).apply {
+            @Suppress("DEPRECATION")
             blendState = BlendState.NORMAL
+            depthTest = URenderPipeline.DepthTest.Always // see UIBlock.PIPELINE
+        }.build()
+
+        private val PIPELINE2 = URenderPipeline.builderWithLegacyShader(
+            "elementa:rounded_rectangle",
+            UGraphics.DrawMode.QUADS,
+            UGraphics.CommonVertexFormats.POSITION_COLOR,
+            readElementaShaderSource("rect", "vsh"),
+            readElementaShaderSource("rounded_rect", "fsh"),
+        ).apply {
+            blendState = BlendState.ALPHA
             depthTest = URenderPipeline.DepthTest.Always // see UIBlock.PIPELINE
         }.build()
 
@@ -86,7 +98,7 @@ open class UIRoundedRectangle(radius: Float) : UIComponent() {
 
             val bufferBuilder = UBufferBuilder.create(UGraphics.DrawMode.QUADS, UGraphics.CommonVertexFormats.POSITION_COLOR)
             UIBlock.drawBlock(bufferBuilder, matrixStack, color, left.toDouble(), top.toDouble(), right.toDouble(), bottom.toDouble())
-            bufferBuilder.build()?.drawAndClose(PIPELINE) {
+            bufferBuilder.build()?.drawAndClose(if (ElementaVersion.atLeastV10Active) PIPELINE2 else PIPELINE) {
                 uniform("u_Radius", radius)
                 uniform("u_InnerRect", left + radius, top + radius, right - radius, bottom - radius)
             }

--- a/src/main/kotlin/gg/essential/elementa/components/UIShape.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIShape.kt
@@ -63,7 +63,7 @@ open class UIShape @JvmOverloads constructor(color: Color = Color.WHITE) : UICom
                 .color(color.red, color.green, color.blue, color.alpha)
                 .endVertex()
         }
-        bufferBuilder.build()?.drawAndClose(PIPELINE)
+        bufferBuilder.build()?.drawAndClose(if (ElementaVersion.atLeastV10Active) PIPELINE2 else PIPELINE)
     }
 
     @Deprecated("Stops working in 1.21.5, see UGraphics.Globals")
@@ -98,7 +98,11 @@ open class UIShape @JvmOverloads constructor(color: Color = Color.WHITE) : UICom
 
     private companion object {
         private val PIPELINE = URenderPipeline.builderWithDefaultShader("elementa:shape", UGraphics.DrawMode.TRIANGLE_FAN, UGraphics.CommonVertexFormats.POSITION_COLOR).apply {
+            @Suppress("DEPRECATION")
             blendState = BlendState.NORMAL.copy(srcAlpha = BlendState.Param.ONE, dstAlpha = BlendState.Param.ZERO)
+        }.build()
+        private val PIPELINE2 = URenderPipeline.builderWithDefaultShader("elementa:shape", UGraphics.DrawMode.TRIANGLE_FAN, UGraphics.CommonVertexFormats.POSITION_COLOR).apply {
+            blendState = BlendState.ALPHA
         }.build()
     }
 }

--- a/src/main/kotlin/gg/essential/elementa/components/UIShape.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIShape.kt
@@ -1,5 +1,6 @@
 package gg.essential.elementa.components
 
+import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.dsl.toConstraint
 import gg.essential.universal.UGraphics
@@ -44,7 +45,7 @@ open class UIShape @JvmOverloads constructor(color: Color = Color.WHITE) : UICom
         val color = this.getColor()
         if (color.alpha == 0) return super.draw(matrixStack)
 
-        if (URenderPipeline.isRequired) {
+        if (URenderPipeline.isRequired || ElementaVersion.atLeastV9Active) {
             draw(matrixStack, color)
         } else {
             @Suppress("DEPRECATION")

--- a/src/main/kotlin/gg/essential/elementa/components/UIText.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIText.kt
@@ -1,5 +1,6 @@
 package gg.essential.elementa.components
 
+import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.UIConstraints
 import gg.essential.elementa.constraints.CenterConstraint
@@ -118,7 +119,7 @@ constructor(
             return super.draw(matrixStack)
         }
 
-        if (!URenderPipeline.isRequired) {
+        if (!URenderPipeline.isRequired && !ElementaVersion.atLeastV9Active) {
             @Suppress("DEPRECATION")
             UGraphics.enableBlend()
         }

--- a/src/main/kotlin/gg/essential/elementa/components/UIWrappedText.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/UIWrappedText.kt
@@ -1,5 +1,6 @@
 package gg.essential.elementa.components
 
+import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.UIConstraints
 import gg.essential.elementa.constraints.CenterConstraint
@@ -152,7 +153,7 @@ open class UIWrappedText @JvmOverloads constructor(
             return super.draw(matrixStack)
         }
 
-        if (!URenderPipeline.isRequired) {
+        if (!URenderPipeline.isRequired && !ElementaVersion.atLeastV9Active) {
             @Suppress("DEPRECATION")
             UGraphics.enableBlend()
         }

--- a/src/main/kotlin/gg/essential/elementa/components/inspector/Inspector.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/inspector/Inspector.kt
@@ -382,7 +382,7 @@ class Inspector @JvmOverloads constructor(
             UGraphics.DrawMode.QUADS,
             UGraphics.CommonVertexFormats.POSITION_COLOR,
         ).apply {
-            blendState = BlendState.NORMAL
+            blendState = BlendState.ALPHA
             depthTest = URenderPipeline.DepthTest.Less
         }.build()
     }

--- a/src/main/kotlin/gg/essential/elementa/font/BasicFontRenderer.kt
+++ b/src/main/kotlin/gg/essential/elementa/font/BasicFontRenderer.kt
@@ -1,5 +1,6 @@
 package gg.essential.elementa.font
 
+import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.constraints.ConstraintType
 import gg.essential.elementa.constraints.resolution.ConstraintVisitor
@@ -148,7 +149,7 @@ class BasicFontRenderer(
         y: Float,
         originalPointSize: Float
     ) {
-        if (URenderPipeline.isRequired) {
+        if (URenderPipeline.isRequired || ElementaVersion.atLeastV9Active) {
             val bufferBuilder = UBufferBuilder.create(UGraphics.DrawMode.QUADS, UGraphics.CommonVertexFormats.POSITION_TEXTURE_COLOR)
             drawStringNow(bufferBuilder, matrixStack, string, color, x, y, originalPointSize)
             bufferBuilder.build()?.drawAndClose(PIPELINE) {

--- a/src/main/kotlin/gg/essential/elementa/font/BasicFontRenderer.kt
+++ b/src/main/kotlin/gg/essential/elementa/font/BasicFontRenderer.kt
@@ -152,7 +152,7 @@ class BasicFontRenderer(
         if (URenderPipeline.isRequired || ElementaVersion.atLeastV9Active) {
             val bufferBuilder = UBufferBuilder.create(UGraphics.DrawMode.QUADS, UGraphics.CommonVertexFormats.POSITION_TEXTURE_COLOR)
             drawStringNow(bufferBuilder, matrixStack, string, color, x, y, originalPointSize)
-            bufferBuilder.build()?.drawAndClose(PIPELINE) {
+            bufferBuilder.build()?.drawAndClose(if (ElementaVersion.atLeastV10Active) PIPELINE2 else PIPELINE) {
                 texture(0, regularFont.getTexture().dynamicGlId)
             }
         } else {
@@ -275,7 +275,11 @@ class BasicFontRenderer(
 
     private companion object {
         private val PIPELINE = URenderPipeline.builderWithDefaultShader("elementa:basic_font", UGraphics.DrawMode.QUADS, UGraphics.CommonVertexFormats.POSITION_COLOR).apply {
+            @Suppress("DEPRECATION")
             blendState = BlendState.NORMAL.copy(srcAlpha = BlendState.Param.ONE, dstAlpha = BlendState.Param.ZERO)
+        }.build()
+        private val PIPELINE2 = URenderPipeline.builderWithDefaultShader("elementa:basic_font", UGraphics.DrawMode.QUADS, UGraphics.CommonVertexFormats.POSITION_COLOR).apply {
+            blendState = BlendState.ALPHA
         }.build()
     }
 }

--- a/src/main/kotlin/gg/essential/elementa/font/FontRenderer.kt
+++ b/src/main/kotlin/gg/essential/elementa/font/FontRenderer.kt
@@ -1,5 +1,6 @@
 package gg.essential.elementa.font
 
+import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.constraints.ConstraintType
 import gg.essential.elementa.constraints.resolution.ConstraintVisitor
@@ -25,7 +26,7 @@ import kotlin.math.max
 /**
  * [MSDF](https://github.com/Chlumsky/msdfgen) Font Renderer
  */
-@Deprecated("Not well maintained. Does not currently support 1.21.5+ at all.")
+@Deprecated("Not well maintained. Does not currently support 1.21.5+ or ElementaVersion.V9 at all.")
 @Suppress("DEPRECATION")
 class FontRenderer(
     private val regularFont: Font,
@@ -133,6 +134,9 @@ class FontRenderer(
         shadow: Boolean,
         shadowColor: Color?
     ) {
+        if (ElementaVersion.atLeastV9Active) {
+            return
+        }
         val effectiveSize = originalPointSize * scale * 1.3623059867f
         val adjustedY = y - effectiveSize / 5
         if (shadow) {

--- a/src/main/kotlin/gg/essential/elementa/utils/LineUtils.kt
+++ b/src/main/kotlin/gg/essential/elementa/utils/LineUtils.kt
@@ -13,7 +13,11 @@ import kotlin.math.sqrt
 
 object LineUtils {
     private val PIPELINE = URenderPipeline.builderWithDefaultShader("elementa:line_strip", UGraphics.DrawMode.TRIANGLE_STRIP, UGraphics.CommonVertexFormats.POSITION_COLOR).apply {
+        @Suppress("DEPRECATION")
         blendState = BlendState.NORMAL
+    }.build()
+    private val PIPELINE2 = URenderPipeline.builderWithDefaultShader("elementa:line_strip", UGraphics.DrawMode.TRIANGLE_STRIP, UGraphics.CommonVertexFormats.POSITION_COLOR).apply {
+        blendState = BlendState.ALPHA
     }.build()
 
     @Deprecated(UMatrixStack.Compat.DEPRECATED, ReplaceWith("drawLine(UMatrixStack(), x1, y1, x2, y2, color, width)"))
@@ -31,7 +35,7 @@ object LineUtils {
         if (URenderPipeline.isRequired || ElementaVersion.atLeastV9Active) {
             val bufferBuilder = UBufferBuilder.create(UGraphics.DrawMode.TRIANGLE_STRIP, UGraphics.CommonVertexFormats.POSITION_COLOR)
             drawLineStrip(bufferBuilder, matrixStack, points, color, width)
-            bufferBuilder.build()?.drawAndClose(PIPELINE)
+            bufferBuilder.build()?.drawAndClose(if (ElementaVersion.atLeastV10Active) PIPELINE2 else PIPELINE)
         } else {
             @Suppress("DEPRECATION")
             UGraphics.enableBlend()

--- a/src/main/kotlin/gg/essential/elementa/utils/LineUtils.kt
+++ b/src/main/kotlin/gg/essential/elementa/utils/LineUtils.kt
@@ -1,5 +1,6 @@
 package gg.essential.elementa.utils
 
+import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.components.UIPoint
 import gg.essential.universal.UGraphics
 import gg.essential.universal.UMatrixStack
@@ -27,7 +28,7 @@ object LineUtils {
 
     @JvmStatic
     fun drawLineStrip(matrixStack: UMatrixStack, points: List<Pair<Number, Number>>, color: Color, width: Float) {
-        if (URenderPipeline.isRequired) {
+        if (URenderPipeline.isRequired || ElementaVersion.atLeastV9Active) {
             val bufferBuilder = UBufferBuilder.create(UGraphics.DrawMode.TRIANGLE_STRIP, UGraphics.CommonVertexFormats.POSITION_COLOR)
             drawLineStrip(bufferBuilder, matrixStack, points, color, width)
             bufferBuilder.build()?.drawAndClose(PIPELINE)

--- a/src/main/kotlin/gg/essential/elementa/utils/image.kt
+++ b/src/main/kotlin/gg/essential/elementa/utils/image.kt
@@ -50,7 +50,7 @@ internal fun drawTexture(
     if (URenderPipeline.isRequired || ElementaVersion.atLeastV9Active) {
         val bufferBuilder = UBufferBuilder.create(UGraphics.DrawMode.QUADS, UGraphics.CommonVertexFormats.POSITION_TEXTURE_COLOR)
         drawTexturedQuad(bufferBuilder)
-        bufferBuilder.build()?.drawAndClose(TEXTURED_QUAD_PIPELINE) {
+        bufferBuilder.build()?.drawAndClose(if (ElementaVersion.atLeastV10Active) TEXTURED_QUAD_PIPELINE2 else TEXTURED_QUAD_PIPELINE) {
             texture(0, glId)
         }
     } else {
@@ -73,7 +73,16 @@ private val TEXTURED_QUAD_PIPELINE = URenderPipeline.builderWithDefaultShader(
     UGraphics.DrawMode.QUADS,
     UGraphics.CommonVertexFormats.POSITION_TEXTURE_COLOR,
 ).apply {
+    @Suppress("DEPRECATION")
     blendState = BlendState.NORMAL
+}.build()
+
+private val TEXTURED_QUAD_PIPELINE2 = URenderPipeline.builderWithDefaultShader(
+    "elementa:textured_quad",
+    UGraphics.DrawMode.QUADS,
+    UGraphics.CommonVertexFormats.POSITION_TEXTURE_COLOR,
+).apply {
+    blendState = BlendState.ALPHA
 }.build()
 
 fun decodeBlurHash(blurHash: String?, width: Int, height: Int, punch: Float = 1f): BufferedImage? {

--- a/src/main/kotlin/gg/essential/elementa/utils/image.kt
+++ b/src/main/kotlin/gg/essential/elementa/utils/image.kt
@@ -1,5 +1,6 @@
 package gg.essential.elementa.utils
 
+import gg.essential.elementa.ElementaVersion
 import gg.essential.universal.UGraphics
 import gg.essential.universal.UMatrixStack
 import gg.essential.universal.render.URenderPipeline
@@ -46,7 +47,7 @@ internal fun drawTexture(
         vertexConsumer.pos(matrixStack, x, y, 0.0).tex(0.0, 0.0).color(red, green, blue, alpha).endVertex()
     }
 
-    if (URenderPipeline.isRequired) {
+    if (URenderPipeline.isRequired || ElementaVersion.atLeastV9Active) {
         val bufferBuilder = UBufferBuilder.create(UGraphics.DrawMode.QUADS, UGraphics.CommonVertexFormats.POSITION_TEXTURE_COLOR)
         drawTexturedQuad(bufferBuilder)
         bufferBuilder.build()?.drawAndClose(TEXTURED_QUAD_PIPELINE) {


### PR DESCRIPTION
This PR introduces two new `ElementaVersions`:
- `V9` switches all components to consistently use `URenderPipeline` on all Minecraft versions (so we don't have to implement `V10` for the legacy code paths)
- `V10` switches all components to use `BlendState.ALPHA` instead of `BlendState.NORMAL`, [which fixes the alpha channel of the render result](https://github.com/EssentialGG/UniversalCraft/pull/105), required for proper compositing with MC's new gui renderer in 1.21.6

Made these separate versions to aid in debugging if your gui is broken by them, so you can apply them separately to figure out which one your gui doesn't handle properly.